### PR TITLE
feat(connections): expose errors module publicly

### DIFF
--- a/welds-connections/src/lib.rs
+++ b/welds-connections/src/lib.rs
@@ -3,7 +3,7 @@ use crate::errors::Result;
 use async_trait::async_trait;
 pub use row::Row;
 pub use transaction::Transaction;
-mod errors;
+pub mod errors;
 pub mod row;
 pub mod transaction;
 


### PR DESCRIPTION
Exposing errors from welds-connections allows to check for specific errors in end-user code.