### PR TITLE
feat: add `ExecuteResult` constructor

### DIFF
--- a/welds-connections/src/lib.rs
+++ b/welds-connections/src/lib.rs
@@ -157,6 +157,10 @@ pub struct ExecuteResult {
 }
 
 impl ExecuteResult {
+    pub fn new(rows_affected: u64) -> Self {
+        Self { rows_affected }
+    }
+
     pub fn rows_affected(&self) -> u64 {
         self.rows_affected
     }


### PR DESCRIPTION
Currently it's impossible to create `ExecuteResult` from an external crate, which in turn means it's not possible to implement custom `Client`s. So this just adds a public constructor.

Or there is a way and I'm just blind. That is possible too. 