### PR TITLE
feat: public update builder

### DIFF
--- a/welds/src/query/builder/mod.rs
+++ b/welds/src/query/builder/mod.rs
@@ -1,7 +1,7 @@
 pub use super::clause::manualwhereparam::ManualWhereParam;
 use super::clause::{self, AsOptField};
 use super::select_cols::SelectBuilder;
-use super::update::bulk::UpdateBuilder;
+pub use super::update::bulk::UpdateBuilder;
 use crate::model_traits::{HasSchema, TableColumns, TableInfo, UniqueIdentifier};
 use crate::query::clause::exists::ExistIn;
 use crate::query::clause::{AsFieldName, ClauseAdder, OrderBy};
@@ -269,7 +269,7 @@ where
     }
 
     /// Changes this query Into a sql UPDATE.
-    /// sets the value from the lambda in the database
+    /// Sets the value from the lambda in the database
     pub fn set<V, FIELD>(
         self,
         lam: impl Fn(<T as HasSchema>::Schema) -> FIELD,
@@ -282,6 +282,20 @@ where
     {
         let ub = UpdateBuilder::new(self);
         ub.set(lam, value)
+    }
+
+    /// Changes this query Into a sql UPDATE.
+    /// Sets a custom [`ClauseAdder`] value from the lambda in the database
+    pub fn set_col<V>(
+        self,
+        lam: impl Fn(<T as HasSchema>::Schema) -> Box<dyn ClauseAdder>,
+    ) -> UpdateBuilder<T>
+    where
+        <T as HasSchema>::Schema: Default,
+        V: 'static + Sync + Send + Clone + Param,
+    {
+        let ub = UpdateBuilder::new(self);
+        ub.set_col::<V>(lam)
     }
 
     /// Nulls out the value from the lambda in the database

--- a/welds/src/query/update/bulk/mod.rs
+++ b/welds/src/query/update/bulk/mod.rs
@@ -35,7 +35,7 @@ where
         }
     }
 
-    /// sets the value from the lambda in the database
+    /// Sets the value from the lambda in the database
     pub fn set<V, FIELD>(
         mut self,
         lam: impl Fn(<T as HasSchema>::Schema) -> FIELD,
@@ -50,6 +50,19 @@ where
         let field = lam(Default::default());
         let col_raw = field.colname().to_string();
         self.sets.push(Box::new(SetColVal { col_raw, val }));
+        self
+    }
+
+    /// Sets a custom [`ClauseAdder`] value from the lambda in the database
+    pub fn set_col<V>(
+        mut self,
+        lam: impl Fn(<T as HasSchema>::Schema) -> Box<dyn ClauseAdder>,
+    ) -> Self
+    where
+        <T as HasSchema>::Schema: Default,
+        V: 'static + Sync + Send + Clone + Param,
+    {
+        self.sets.push(lam(Default::default()));
         self
     }
 


### PR DESCRIPTION
I had no idea rust allowed you to return types from pub functions that were not exported themselves. :laughing: This meant that `UpdateBuilder` could be used, but not returned from downstream functions or saved into structs. I also added `set_col`, which allows to attach any `ClauseAdder` similar to `QueryBuilder::where_col`.