### PR TITLE
feat: add generated column metadata struct

### DIFF
--- a/welds-macros/src/info.rs
+++ b/welds-macros/src/info.rs
@@ -8,6 +8,7 @@ use syn::Ident;
 pub(crate) struct Info {
     pub defstruct: Ident,
     pub schemastruct: Ident,
+    pub colstruct: Ident,
     pub columns: Vec<Column>,
     pub pks: Vec<Column>,
     pub relations: Vec<Relation>,
@@ -26,6 +27,8 @@ impl Info {
         let defstruct = attributes::get_scructname(ast);
         let schemastruct_name = format!("{}Schema", defstruct);
         let schemastruct = Ident::new(&schemastruct_name, defstruct.span());
+        let colstruct_name = format!("{}Columns", defstruct);
+        let colstruct = Ident::new(&colstruct_name, defstruct.span());
         let relations_struct_name = format!("{}Relation", defstruct);
         let relations_struct = Ident::new(&relations_struct_name, defstruct.span());
         let tablename = attributes::get_tablename(ast);
@@ -42,6 +45,7 @@ impl Info {
             relations,
             hooks,
             schemastruct,
+            colstruct,
             relations_struct,
             tablename,
             schemaname,
@@ -64,6 +68,7 @@ mod tests {
             Info {
                 defstruct: Ident::new("Mock", Span::call_site()),
                 schemastruct: Ident::new("MockSchema", Span::call_site()),
+                colstruct: Ident::new("MockColumns", Span::call_site()),
                 columns: Vec::default(),
                 pks: Vec::default(),
                 relations: Vec::default(),

--- a/welds/src/model_traits/mod.rs
+++ b/welds/src/model_traits/mod.rs
@@ -11,7 +11,7 @@ pub trait TableInfo {
 }
 
 /// The db column name to use for a field
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub struct Column {
     name: String,
     rust_type: String,
@@ -46,6 +46,8 @@ impl Column {
 /// How welds knows what columns exist on your model
 /// This trait is impl by the model's schema not the model
 pub trait TableColumns {
+    type ColumnStruct: TableColumns + Default;
+
     // Used to identify models that have N columns in their primary_key
     fn primary_keys() -> Vec<Column>;
     fn columns() -> Vec<Column>;


### PR DESCRIPTION
This adds a new generated struct for each table with the `Column` definitions as fields. This makes it so column definitions can be easily accessed by their name and not just by searching a `Vec<Column>`. This struct also gets a `TableColumns` impl and is attached to `TableColumns` by an assoc type.

My motivation was wanting to implement something similar to `where_col` but with column picker instead of a condition.
For example:

```rust
#[derive(welds::WeldsModel)]
pub struct Model {
    pub id: i32,
}

fn col_type<T>(
    column: impl Fn(<<T as HasSchema>::Schema as TableColumns>::ColumnStruct) -> Column,
) -> String
where
    T: HasSchema,
    <T as HasSchema>::Schema: TableColumns,
{
    column(Default::default()).rust_type().to_owned()
}

fn main() {
    println!("{}", col_type::<Model>(|t| t.id));
}
```

More specifically, I'm playing around with an insert builder that has support for configurable on conflict updates. But I'm not sure it will ever work in anything other than postgres.