### PR TITLE
feat: filter results via IN statements with multiple values

### DIFF
--- a/tests/sqlite/tests/all_tests.rs
+++ b/tests/sqlite/tests/all_tests.rs
@@ -503,3 +503,18 @@ fn should_be_able_to_write_a_custom_set2() {
         q.run(&conn).await.unwrap();
     })
 }
+
+#[test]
+fn should_be_able_to_filter_by_multiple_values() {
+    async_std::task::block_on(async {
+        let conn = get_conn().await;
+
+        let query = Product::all().where_in(|p| p.name, vec!["cat","dog"]);
+        let results = query.run(&conn).await.unwrap();
+        assert_eq!(results.len(), 2);
+
+        let query = Product::all().where_in(|p| p.id, vec![2,3,4]);
+        let results = query.run(&conn).await.unwrap();
+        assert_eq!(results.len(), 3);
+    })
+}

--- a/welds/src/query/clause/clause_adder.rs
+++ b/welds/src/query/clause/clause_adder.rs
@@ -1,4 +1,4 @@
-use super::{ClauseColManual, ClauseColVal, ClauseColValEqual, ClauseColValList};
+use super::{ClauseColManual, ClauseColVal, ClauseColValEqual, ClauseColValIn, ClauseColValList};
 use super::{Param, ParamArgs};
 use crate::writers::NextParam;
 use crate::Syntax;
@@ -116,6 +116,38 @@ where
         let np = next_params.next();
         parts.push("(");
         parts.push(&np);
+        parts.push(")");
+        let clause: String = parts.join("");
+        Some(clause)
+    }
+}
+
+impl<T> ClauseAdder for ClauseColValIn<T>
+where
+    T: Clone + Send + Sync + Param,
+{
+    fn bind<'lam, 'args, 'p>(&'lam self, args: &'args mut ParamArgs<'p>)
+    where
+        'lam: 'p,
+    {
+        for item in &self.list {
+            args.push(item);
+        }
+    }
+
+    fn clause(&self, _syntax: Syntax, alias: &str, next_params: &NextParam) -> Option<String> {
+        let col = format!("{}.{}", alias, self.col);
+        let mut parts = vec![col.as_str()];
+        let np = next_params.next();
+
+        parts.push(" ");
+        parts.push(self.operator);
+        parts.push(" ");
+        parts.push("(");
+        for (i, _in) in self.list.iter().enumerate() {
+            if i > 0 { parts.push(",") }
+            parts.push(&np);
+        }
         parts.push(")");
         let clause: String = parts.join("");
         Some(clause)

--- a/welds/src/query/clause/mod.rs
+++ b/welds/src/query/clause/mod.rs
@@ -48,6 +48,12 @@ pub struct ClauseColValEqual<T> {
     pub val: Option<T>,
 }
 
+pub struct ClauseColValIn<T> {
+    pub col: String,
+    pub operator: &'static str,
+    pub list: Vec<T>,
+}
+
 pub struct ClauseColValList<T> {
     pub col: String,
     pub operator: &'static str,


### PR DESCRIPTION
Proposal / draft: adds a new method `where_in` for filtering on a column by a given set of values. Eg:
```rust

let selected_flavours = vec!["chocolate", "vanilla", "mint"];
let ice_creams = IceCream::all().where_in(|ic| ic.flavour, selected_flavours);

=> SELECT * FROM ice_creams WHERE flavour IN ("chocolate","vanilla","mint")
```

What do you think?
