### PR TITLE
feat: implement `HasOne` relationship

### DIFF
--- a/tests/sqlite/src/models/mod.rs
+++ b/tests/sqlite/src/models/mod.rs
@@ -47,7 +47,7 @@ pub struct User {
 
 #[derive(Debug, WeldsModel, PartialEq, Eq)]
 #[welds(table = "Profiles")]
-#[welds(BelongsToOne(user, User, "id"))]
+#[welds(BelongsToOne(user, User, "profile_id"))]
 pub struct Profile {
     #[welds(primary_key)]
     pub id: i32,

--- a/tests/sqlite/src/models/mod.rs
+++ b/tests/sqlite/src/models/mod.rs
@@ -35,17 +35,17 @@ pub struct StringThing {
     pub value: String,
 }
 
-#[derive(Debug, WeldsModel)]
+#[derive(Debug, WeldsModel, PartialEq, Eq)]
 #[welds(table = "Users")]
 #[welds(HasOne(profile, Profile, "profile_id"))]
 pub struct User {
     #[welds(primary_key)]
     pub id: i32,
     pub profile_id: Option<i32>,
-    pub name: String
+    pub name: String,
 }
 
-#[derive(Debug, WeldsModel)]
+#[derive(Debug, WeldsModel, PartialEq, Eq)]
 #[welds(table = "Profiles")]
 #[welds(BelongsToOne(user, User, "id"))]
 pub struct Profile {

--- a/tests/sqlite/src/models/mod.rs
+++ b/tests/sqlite/src/models/mod.rs
@@ -34,3 +34,22 @@ pub struct StringThing {
     pub id: String,
     pub value: String,
 }
+
+#[derive(Debug, WeldsModel)]
+#[welds(table = "Users")]
+#[welds(HasOne(profile, Profile, "profile_id"))]
+pub struct User {
+    #[welds(primary_key)]
+    pub id: i32,
+    pub profile_id: Option<i32>,
+    pub name: String
+}
+
+#[derive(Debug, WeldsModel)]
+#[welds(table = "Profiles")]
+#[welds(BelongsToOne(user, User, "id"))]
+pub struct Profile {
+    #[welds(primary_key)]
+    pub id: i32,
+    pub image_url: String,
+}

--- a/tests/sqlite/tests/all_tests.rs
+++ b/tests/sqlite/tests/all_tests.rs
@@ -245,8 +245,8 @@ fn should_be_able_to_create_a_new_product() {
 fn should_be_able_to_scan_for_all_tables() {
     async_std::task::block_on(async {
         let conn = get_conn().await;
-        let tables = welds::detect::find_tables(&conn).await.unwrap();
-        assert_eq!(14, tables.len());
+        let tables = welds::detect::find_all_tables(&conn).await.unwrap();
+        assert_eq!(16, tables.len());
     })
 }
 
@@ -514,44 +514,5 @@ fn should_be_able_to_filter_by_multiple_values() {
         let query = Product::all().where_col(|p| p.name.in_list(&["cat", "dog"]));
         let results = query.run(&conn).await.unwrap();
         assert_eq!(results.len(), 2);
-    })
-}
-
-#[test]
-fn should_model_one_to_one_associations() {
-    use sqlite_test::models::User;
-    use sqlite_test::models::Profile;
-
-    async_std::task::block_on(async {
-        let conn = get_conn().await;
-
-        let mut profile = Profile::new();
-        profile.id = 1;
-        profile.image_url = "example.com/cat.jpeg".to_owned();
-        profile.save(&conn).await.unwrap();
-
-        let mut user = User::new();
-        user.id = 1;
-        user.profile_id = Some(1);
-        user.name = "Jimmy".to_owned();
-        user.save(&conn).await.unwrap();
-
-        let result = User::all()
-            .where_relation(
-                |u| u.profile,
-                Profile::where_col(|p| p.image_url.equal("example.com/cat.jpeg"))
-            )
-            .run(&conn).await.unwrap();
-
-        assert_eq!(result.len(), 1);
-
-        let result = Profile::all()
-            .where_relation(
-                |p| p.user,
-                User::where_col(|u| u.name.equal("Jimmy"))
-            )
-            .run(&conn).await.unwrap();
-
-        assert_eq!(result.len(), 1);
     })
 }

--- a/tests/sqlite/tests/sub_query_tests/mod.rs
+++ b/tests/sqlite/tests/sub_query_tests/mod.rs
@@ -1,3 +1,5 @@
+use super::get_conn;
+use welds::connections::TransactStart;
 use welds::Syntax;
 use welds::WeldsModel;
 
@@ -96,5 +98,183 @@ fn three_levels_down() {
             .to_sql(Syntax::Sqlite);
 
         assert_eq!(q, "SELECT t3.\"pid\", t3.\"name\" FROM Products t3 WHERE ( t3.pid = ? AND EXISTS ( SELECT product_id FROM orders t2 WHERE t2.oid = ? AND t2.product_id = t3.pid AND EXISTS ( SELECT pid FROM Products t1 WHERE t1.pid = ? AND t1.pid = t2.product_id ) ) )");
+    })
+}
+
+#[test]
+fn should_be_able_to_query_one_to_one_with_where_relation_from_source() {
+    use sqlite_test::models::Profile;
+    use sqlite_test::models::User;
+
+    async_std::task::block_on(async {
+        let conn = get_conn().await;
+        let trans = conn.begin().await.unwrap();
+
+        // make some play data
+        let mut profile1 = Profile::new();
+        profile1.id = 1;
+        profile1.image_url = "example.com/cat.jpeg".to_owned();
+        profile1.save(&conn).await.unwrap();
+
+        let mut profile2 = Profile::new();
+        profile2.id = 2;
+        profile2.image_url = "example.com/cat.jpeg".to_owned();
+        profile2.save(&conn).await.unwrap();
+
+        let mut user1 = User::new();
+        user1.profile_id = Some(1);
+        user1.name = "Jimmy".to_owned();
+        user1.save(&conn).await.unwrap();
+
+        let mut user2 = User::new();
+        user2.profile_id = None;
+        user2.name = "Jimmy".to_owned();
+        user2.save(&conn).await.unwrap();
+
+        // run the query
+        let sub_query_profile = Profile::where_col(|p| p.image_url.equal("example.com/cat.jpeg"));
+        let query = User::all().where_relation(|u| u.profile, sub_query_profile);
+        eprintln!("QUERY: {}", query.to_sql(Syntax::Sqlite));
+        let data = query.run(&conn).await.unwrap();
+
+        // Make sure we only get the expected row
+        assert_eq!(data.len(), 1);
+        assert_eq!(data[0].as_ref(), user1.as_ref());
+
+        trans.rollback().await.unwrap();
+    })
+}
+
+#[test]
+fn should_be_able_to_query_one_to_one_with_where_relation_from_desc() {
+    use sqlite_test::models::Profile;
+    use sqlite_test::models::User;
+
+    async_std::task::block_on(async {
+        let conn = get_conn().await;
+        let trans = conn.begin().await.unwrap();
+
+        // make some play data
+        let mut profile1 = Profile::new();
+        profile1.id = 1;
+        profile1.image_url = "example.com/cat.jpeg".to_owned();
+        profile1.save(&conn).await.unwrap();
+
+        let mut profile2 = Profile::new();
+        profile2.id = 2;
+        profile2.image_url = "example.com/cat.jpeg".to_owned();
+        profile2.save(&conn).await.unwrap();
+
+        let mut user1 = User::new();
+        user1.profile_id = Some(1);
+        user1.name = "Jimmy".to_owned();
+        user1.save(&conn).await.unwrap();
+
+        let mut user2 = User::new();
+        user2.profile_id = None;
+        user2.name = "Jimmy".to_owned();
+        user2.save(&conn).await.unwrap();
+
+        // run the query
+        let sub_query_user = User::where_col(|u| u.name.equal("Jimmy"));
+        let query = Profile::all().where_relation(|u| u.user, sub_query_user);
+        eprintln!("QUERY: {}", query.to_sql(Syntax::Sqlite));
+        let data = query.run(&conn).await.unwrap();
+
+        // Make sure we only get the expected row
+        assert_eq!(data.len(), 1);
+        assert_eq!(data[0].as_ref(), profile1.as_ref());
+
+        trans.rollback().await.unwrap();
+    })
+}
+
+#[test]
+fn should_be_able_to_query_one_to_one_with_map_query_from_source() {
+    use sqlite_test::models::Profile;
+    use sqlite_test::models::User;
+
+    async_std::task::block_on(async {
+        let conn = get_conn().await;
+        let trans = conn.begin().await.unwrap();
+
+        // make some play data
+        let mut profile1 = Profile::new();
+        profile1.id = 1;
+        profile1.image_url = "example.com/cat.jpeg".to_owned();
+        profile1.save(&conn).await.unwrap();
+
+        let mut profile2 = Profile::new();
+        profile2.id = 2;
+        profile2.image_url = "example.com/cat.jpeg".to_owned();
+        profile2.save(&conn).await.unwrap();
+
+        let mut user1 = User::new();
+        user1.profile_id = Some(1);
+        user1.name = "Jimmy".to_owned();
+        user1.save(&conn).await.unwrap();
+
+        let mut user2 = User::new();
+        user2.profile_id = None;
+        user2.name = "Jimmy".to_owned();
+        user2.save(&conn).await.unwrap();
+
+        // run the query
+        let query = User::all()
+            .map_query(|u| u.profile)
+            .where_col(|p| p.image_url.equal("example.com/cat.jpeg"));
+        eprintln!("QUERY: {}", query.to_sql(Syntax::Sqlite));
+        let data = query.run(&conn).await.unwrap();
+
+        // Make sure we only get the expected row
+        assert_eq!(data.len(), 1);
+        assert_eq!(data[0].as_ref(), profile1.as_ref());
+
+        trans.rollback().await.unwrap();
+    })
+}
+
+#[test]
+fn should_be_able_to_query_one_to_one_with_map_query_from_desc() {
+    use sqlite_test::models::Profile;
+    use sqlite_test::models::User;
+
+    async_std::task::block_on(async {
+        let conn = get_conn().await;
+        let trans = conn.begin().await.unwrap();
+
+        // make some play data
+        let mut profile1 = Profile::new();
+        profile1.id = 1;
+        profile1.image_url = "example.com/cat.jpeg".to_owned();
+        profile1.save(&conn).await.unwrap();
+
+        let mut profile2 = Profile::new();
+        profile2.id = 2;
+        profile2.image_url = "example.com/cat.jpeg".to_owned();
+        profile2.save(&conn).await.unwrap();
+
+        let mut user1 = User::new();
+        user1.profile_id = Some(1);
+        user1.name = "Jimmy".to_owned();
+        user1.save(&conn).await.unwrap();
+
+        let mut user2 = User::new();
+        user2.profile_id = None;
+        user2.name = "Jimmy".to_owned();
+        user2.save(&conn).await.unwrap();
+
+        // run the query
+        let query = Profile::all()
+            .map_query(|p| p.user)
+            .where_col(|u| u.name.equal("Jimmy"));
+        eprintln!("QUERY: {}", query.to_sql(Syntax::Sqlite));
+        let data = query.run(&conn).await.unwrap();
+
+        // Make sure we only get the expected row
+        assert_eq!(data.len(), 1);
+        assert_eq!(data[0].as_ref(), user1.as_ref());
+
+        trans.rollback().await.unwrap();
     })
 }

--- a/tests/testlib/databases/sqlite/01_create_tables.sql
+++ b/tests/testlib/databases/sqlite/01_create_tables.sql
@@ -38,3 +38,14 @@ CREATE TABLE extra_types (
     datetime_col DATETIME NOT NULL,
     datetimetz_col DATETIME NOT NULL
 );
+
+CREATE TABLE Users (
+    id INTEGER PRIMARY KEY,
+    profile_id INTEGER,
+    name TEXT
+);
+
+CREATE TABLE Profiles (
+    id INTEGER PRIMARY KEY,
+    image_url TEXT
+);

--- a/welds-cli/src/config/table.rs
+++ b/welds-cli/src/config/table.rs
@@ -12,6 +12,8 @@ pub struct Table {
     pub r#type: String,            // This could be a table or view
     pub columns: Vec<Column>,      // What are the columns on this table
     pub belongs_to: Vec<Relation>, // list of objects this object belongs to
+    pub belongs_to_one: Vec<Relation>, // the objects this object belongs to
+    pub has_one: Vec<Relation>,    // which object this object has one of
     pub has_many: Vec<Relation>,   // what objects this object has many of
     pub database: DbProvider,      // what DB this object was scanned from.
 }
@@ -33,6 +35,8 @@ impl Table {
             columns: vec![],
             r#type: type_str(table_def.ty()).to_string(),
             belongs_to: table_def.belongs_to().iter().map(|x| x.into()).collect(),
+            belongs_to: table_def.belongs_to_one().iter().map(|x| x.into()).collect(),
+            has_one: table_def.has_one().iter().map(|x| x.into()).collect(),
             has_many: table_def.has_many().iter().map(|x| x.into()).collect(),
             database: provider,
         };
@@ -48,6 +52,8 @@ impl Table {
         self.schema = table_def.ident().schema().map(|s| s.to_string());
         self.r#type = type_str(table_def.ty()).to_string();
         self.belongs_to = table_def.belongs_to().iter().map(|x| x.into()).collect();
+        self.belongs_to_one = table_def.belongs_to_one().iter().map(|x| x.into()).collect();
+        self.has_one = table_def.has_one().iter().map(|x| x.into()).collect();
         self.has_many = table_def.has_many().iter().map(|x| x.into()).collect();
         self.update_cols_from(table_def.columns());
         self.database = provider;

--- a/welds-cli/src/generators/models/struct_def.rs
+++ b/welds-cli/src/generators/models/struct_def.rs
@@ -55,14 +55,26 @@ fn build_welds_table(table: &Table) -> TokenStream {
 fn build_relations(table: &Table, all: &[Table]) -> TokenStream {
     let mut list = Vec::default();
     let hm = quote::format_ident!("HasMany");
+    let ho = quote::format_ident!("HasOne");
     let bt = quote::format_ident!("BelongsTo");
+    let bto = quote::format_ident!("BelongsToOne");
     for relation in &table.has_many {
         if let Some(q) = build_relation(&hm, relation, all) {
             list.push(q);
         }
     }
+    for relation in &table.has_one {
+        if let Some(q) = build_relation(&ho, relation, all) {
+            list.push(q);
+        }
+    }
     for relation in &table.belongs_to {
         if let Some(q) = build_relation(&bt, relation, all) {
+            list.push(q);
+        }
+    }
+    for relation in &table.belongs_to_one {
+        if let Some(q) = build_relation(&bto, relation, all) {
             list.push(q);
         }
     }

--- a/welds-macros/src/attributes.rs
+++ b/welds-macros/src/attributes.rs
@@ -127,7 +127,25 @@ pub(crate) fn get_relations(ast: &syn::DeriveInput) -> Result<Vec<Relation>> {
         .map(|m| Relation::new(m, "BelongsTo"))
         .collect();
     let mut relations2 = relations2?;
-    let relations: Vec<_> = relations1.drain(..).chain(relations2.drain(..)).collect();
+    let relations3: Result<Vec<_>> = inners
+        .iter()
+        .filter_map(|m| as_metalist_ref(m))
+        .filter(|m| m.path.is_ident("HasOne"))
+        .map(|m| Relation::new(m, "HasOne"))
+        .collect();
+    let mut relations3 = relations3?;
+    let relations4: Result<Vec<_>> = inners
+        .iter()
+        .filter_map(|m| as_metalist_ref(m))
+        .filter(|m| m.path.is_ident("BelongsToOne"))
+        .map(|m| Relation::new(m, "BelongsToOne"))
+        .collect();
+    let mut relations4 = relations4?;
+    let relations: Vec<_> = relations1.drain(..)
+        .chain(relations2.drain(..))
+        .chain(relations3.drain(..))
+        .chain(relations4.drain(..))
+        .collect();
 
     Ok(relations)
 }

--- a/welds-macros/src/relation.rs
+++ b/welds-macros/src/relation.rs
@@ -13,10 +13,11 @@ pub(crate) struct Relation {
 impl Relation {
     pub(crate) fn new(list: &MetaList, kind: &'static str) -> Result<Self> {
         let badformat = || {
-            if kind == "BelongsTo" {
-                Err(FORMAT_ERR_BELONGS_TO.to_owned())
-            } else {
-                Err(FORMAT_ERR_HAS_MANY.to_owned())
+            match kind {
+                "BelongsTo" => Err(FORMAT_ERR_BELONGS_TO.to_owned()),
+                "HasMany" => Err(FORMAT_ERR_HAS_MANY.to_owned()),
+                "BelongsToOne" => Err(FORMAT_ERR_BELONGS_TO_ONE.to_owned()),
+                _ => Err(FORMAT_ERR_HAS_ONE.to_owned()),
             }
         };
 
@@ -71,6 +72,14 @@ impl Relation {
 const FORMAT_ERR_HAS_MANY: &str = "Invalid Format For HasMany:
 HasMany should be in for format of
 [ welds(HasMany(field, struct, foreign_key_str) )]";
+
+const FORMAT_ERR_HAS_ONE: &str = "Invalid Format For HasOne:
+HasOne should be in for format of
+[ welds(HasOne(field, struct, foreign_key_str) )]";
+
+const FORMAT_ERR_BELONGS_TO_ONE: &str = "Invalid Format For BelongsToOne:
+BelongsToOne should be in for format of
+[ welds(BelongsToOne(field, struct, foreign_key_str) )]";
 
 const FORMAT_ERR_BELONGS_TO: &str = "Invalid Format For BelongsTo:
 BelongsTo should be in for format of

--- a/welds/src/detect/table_def.rs
+++ b/welds/src/detect/table_def.rs
@@ -9,7 +9,9 @@ pub struct TableDef {
     pub(crate) ty: DataType,
     pub(crate) columns: Vec<ColumnDef>, // What are the columns on this table
     pub(crate) has_many: Vec<RelationDef>,
+    pub(crate) has_one: Vec<RelationDef>,
     pub(crate) belongs_to: Vec<RelationDef>,
+    pub(crate) belongs_to_one: Vec<RelationDef>,
     pub(crate) syntax: Syntax,
 }
 
@@ -28,6 +30,12 @@ impl TableDef {
     }
     pub fn belongs_to(&self) -> &[RelationDef] {
         &self.belongs_to
+    }
+    pub fn has_one(&self) -> &[RelationDef] {
+        &self.has_one
+    }
+    pub fn belongs_to_one(&self) -> &[RelationDef] {
+        &self.belongs_to_one
     }
     pub fn syntax(&self) -> Syntax {
         self.syntax
@@ -204,6 +212,8 @@ pub mod mock {
                 columns: Vec::default(),
                 has_many: Vec::default(),
                 belongs_to: Vec::default(),
+                has_one: Vec::default(),
+                belongs_to_one: Vec::default(),
             })
         }
 

--- a/welds/src/lib.rs
+++ b/welds/src/lib.rs
@@ -31,6 +31,7 @@
 //!
 //! Welds Supports:
 //! - BelongsTo
+//! - HasOne
 //! - HasMany
 //!
 //! They are both in the format:

--- a/welds/src/relations/mod.rs
+++ b/welds/src/relations/mod.rs
@@ -63,6 +63,68 @@ impl<R> Relationship<R> for HasMany<R> {
     }
 }
 
+pub struct HasOne<T> {
+    _t: PhantomData<T>,
+    foreign_key: &'static str,
+}
+
+impl<T> HasOne<T> {
+    pub fn using(fk: &'static str) -> HasOne<T> {
+        HasOne {
+            _t: Default::default(),
+            foreign_key: fk,
+        }
+    }
+}
+
+impl<R> Relationship<R> for HasOne<R> {
+    fn my_key<ME, THEM>(&self) -> String
+    where
+        ME: UniqueIdentifier,
+        THEM: UniqueIdentifier,
+    {
+        self.foreign_key.to_owned()
+    }
+    fn their_key<ME, THEM>(&self) -> String
+    where
+        ME: UniqueIdentifier,
+        THEM: UniqueIdentifier,
+    {
+        ME::id_column().name().to_owned()
+    }
+}
+
+pub struct BelongsToOne<T> {
+    _t: PhantomData<T>,
+    foreign_key: &'static str,
+}
+
+impl<T> BelongsToOne<T> {
+    pub fn using(fk: &'static str) -> BelongsToOne<T> {
+        BelongsToOne {
+            _t: Default::default(),
+            foreign_key: fk,
+        }
+    }
+}
+
+impl<R> Relationship<R> for BelongsToOne<R> {
+    fn my_key<ME, THEM>(&self) -> String
+    where
+        ME: UniqueIdentifier,
+        THEM: UniqueIdentifier,
+    {
+        THEM::id_column().name().to_owned()
+    }
+    fn their_key<ME, THEM>(&self) -> String
+    where
+        ME: UniqueIdentifier,
+        THEM: UniqueIdentifier,
+    {
+        self.foreign_key.to_owned()
+    }
+}
+
 pub trait Relationship<R> {
     fn their_key<R2, T>(&self) -> String
     where


### PR DESCRIPTION
Adds `HasOne` and corresponding `BelongsToOne` relationships for one-to-one associations.