### PR TITLE
Allow map_query without moving

### DIFF
--- a/welds/src/query/builder/mod.rs
+++ b/welds/src/query/builder/mod.rs
@@ -202,7 +202,7 @@ where
         let inner_tn = <R as HasSchema>::Schema::identifier();
         let inner_tn = inner_tn.join(".");
         let inner_col = ship.their_key::<R::Schema, T::Schema>();
-        let mut exist_in = ExistIn::new(filter, out_col, inner_tn, inner_col);
+        let mut exist_in = ExistIn::new(&filter, out_col, inner_tn, inner_col);
         exist_in.set_aliases(&self.alias_asigner);
         self.exist_ins.push(exist_in);
         self
@@ -210,7 +210,7 @@ where
 
     /// Results in a query that is mapped into the query of one of its relationships
     pub fn map_query<R, Ship>(
-        self,
+        &self,
         relationship: impl Fn(<T as HasRelations>::Relation) -> Ship,
     ) -> QueryBuilder<R>
     where

--- a/welds/src/query/clause/exists.rs
+++ b/welds/src/query/clause/exists.rs
@@ -23,7 +23,7 @@ pub struct ExistIn {
 
 impl ExistIn {
     pub(crate) fn new<T>(
-        sb: QueryBuilder<T>,
+        sb: &QueryBuilder<T>,
         outer_column: String,
         inner_tablename: String,
         inner_column: String,
@@ -32,12 +32,12 @@ impl ExistIn {
             outer_column,
             inner_column,
             inner_tablename,
-            inner_tablealias: sb.alias,
-            wheres: sb.wheres,
-            inner_exists_ins: sb.exist_ins,
+            inner_tablealias: sb.alias.clone(),
+            wheres: sb.wheres.clone(),
+            inner_exists_ins: sb.exist_ins.clone(),
             limit: sb.limit,
             offset: sb.offset,
-            orderby: sb.orderby,
+            orderby: sb.orderby.clone(),
         }
     }
 


### PR DESCRIPTION
Proposal: allow calling `.map_query()` on an instance of `QueryBuilder` without consuming/moving `self`. Eg:

```rust

let top_teams_query = Team::all().where_col(|t| t.trophies.gt(10));

let related_players = top_teams_query.map_query(|t| t.players).run(&client).await?;
let related_cities = top_teams_query.map_query(|t| t.city).run(&client).await?;
```

What do you think?