### PR TITLE
Includes: sharing boxed objects across threads

### DIFF
--- a/welds/src/dataset/mod.rs
+++ b/welds/src/dataset/mod.rs
@@ -12,11 +12,11 @@ mod tests;
 pub struct DataSet<T> {
     // not sure if we want to use state or not
     primary: Vec<DbState<T>>,
-    related: Vec<Box<dyn RelatedSetAccesser>>,
+    related: Vec<Box<dyn RelatedSetAccesser + Send>>,
 }
 
 impl<T> DataSet<T> {
-    pub(crate) fn new(primary: Vec<DbState<T>>, related: Vec<Box<dyn RelatedSetAccesser>>) -> Self {
+    pub(crate) fn new(primary: Vec<DbState<T>>, related: Vec<Box<dyn RelatedSetAccesser + Send>>) -> Self {
         Self { primary, related }
     }
 

--- a/welds/src/query/include/mod.rs
+++ b/welds/src/query/include/mod.rs
@@ -14,7 +14,7 @@ mod tests;
 /// An un-executed Query Selecting a model AND its relationship objects.
 pub struct IncludeBuilder<T> {
     qb: QueryBuilder<T>,
-    related: Vec<Box<dyn RelatedQuery<T>>>,
+    related: Vec<Box<dyn RelatedQuery<T> + Sync + Send>>,
 }
 
 impl<T> IncludeBuilder<T>

--- a/welds/src/query/include/related_query.rs
+++ b/welds/src/query/include/related_query.rs
@@ -16,7 +16,7 @@ pub(crate) trait RelatedQuery<R> {
         &self,
         primary_query: &QueryBuilder<R>,
         client: &dyn Client,
-    ) -> Result<Box<dyn RelatedSetAccesser>>;
+    ) -> Result<Box<dyn RelatedSetAccesser + Send>>;
 }
 
 pub(crate) struct IncludeQuery<R, Ship>
@@ -48,7 +48,7 @@ where
         &self,
         primary_query: &QueryBuilder<T>,
         client: &dyn Client,
-    ) -> Result<Box<dyn RelatedSetAccesser>> {
+    ) -> Result<Box<dyn RelatedSetAccesser + Send>> {
         let primary_query = primary_query.clone();
 
         let mut qb: QueryBuilder<R> = QueryBuilder::new();
@@ -105,7 +105,7 @@ pub(crate) trait SetDowncast {
     ) -> Option<&mut RelatedSet<R, Ship>>;
 }
 
-impl SetDowncast for Box<dyn RelatedSetAccesser> {
+impl SetDowncast for Box<dyn RelatedSetAccesser + Send> {
     fn downcast_ref<R: 'static, Ship: 'static + Relationship<R>>(
         &self,
     ) -> Option<&RelatedSet<R, Ship>> {


### PR DESCRIPTION
I just tried out the includes branch in an app that's using Tokio and [Tauri](https://tauri.app/) and the compiler is complaining that's it's unsure if some of these boxed objects that get returned in async functions can be shared safely across threads. 

Example:

```
error[E0277]: `dyn related_query::RelatedQuery<Contact> + std::marker::Send` cannot be shared between threads safely
   --> src/commands/groups.rs:164:1
    |
164 |   #[tauri::command]
    |   ^^^^^^^^^^^^^^^^^ `dyn related_query::RelatedQuery<Contact> + std::marker::Send` cannot be shared between threads safely
    |
   ::: src/lib.rs:113:25
[snip...]
    = help: the trait `Sync` is not implemented for `dyn related_query::RelatedQuery<Contact> + std::marker::Send`
    = note: required for `Unique<dyn related_query::RelatedQuery<Contact> + std::marker::Send>` to implement `Sync`
note: required because it appears within the type `Box<dyn related_query::RelatedQuery<Contact> + std::marker::Send>`
   --> [...]/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/boxed.rs:231:12
    |
231 | pub struct Box<
    |            ^^^
    = note: required for `std::slice::Iter<'_, Box<dyn related_query::RelatedQuery<Contact> + std::marker::Send>>` to implement `std::marker::Send`
note: required because it's used within this `async` fn body
   --> [...]/welds/welds/src/query/include/exec.rs:32:5
    |
32  | /     {
33  | |         let primary = self.qb.run(client).await?;
34  | |
35  | |         let mut related = Vec::default();
...   |
40  | |         Ok(DataSet::new(primary, related))
41  | |     }
    | |_____^
note: required because it's used within this `async` fn body
   --> src/models/contacts.rs:379:113
```   

I think the executor for Tauri's backend wraps the output in a `Future` that imposes some additional restrictions around the thread safety of boxed objects..?

It compiles after specifying a few extra `Send` and `Sync` trait bounds.