### PR TITLE
QueryBuilder: fetch a single object

### DIFF
--- a/tests/sqlite/tests/all_tests.rs
+++ b/tests/sqlite/tests/all_tests.rs
@@ -516,3 +516,14 @@ fn should_be_able_to_filter_by_multiple_values() {
         assert_eq!(results.len(), 2);
     })
 }
+
+#[test]
+fn should_be_able_to_fetch_a_single_object() {
+    async_std::task::block_on(async {
+        let conn = get_conn().await;
+        let result: DbState<Product> = Product::where_col(|p| p.id.gt(1))
+            .fetch_one(&conn)
+            .await
+            .unwrap();
+    })
+}

--- a/welds/src/query/select/mod.rs
+++ b/welds/src/query/select/mod.rs
@@ -118,6 +118,18 @@ where
         }
         Ok(objs)
     }
+
+    pub async fn fetch_one<'q, 'c>(&self, client: &'c dyn Client) -> Result<DbState<T>>
+    where
+        'q: 'c,
+        <T as HasSchema>::Schema: TableInfo + TableColumns,
+        T: TryFrom<Row>,
+        WeldsError: From<<T as TryFrom<Row>>::Error>,
+    {
+        let mut query = self.clone();
+        query.limit = Some(1);
+        query.run(client).await?.into_iter().nth(0).ok_or(WeldsError::RowNowFound)
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Proposal/PR: adds a `fetch_one()` method on `QueryBuilder` (or it could be `get_one()`, `return_one()`?) which returns a singlular `Result<DbState<T>>` instead of a `Result<Vec<DbState<T>>>`.

Migrating from sqlx to welds, I have about a dozen bits of code that used to look like this:

```rust
some_query.fetch_one(&db_pool).await?
```

but to achieve the same thing in welds it currently looks like this :cry: 

```rust
some_query
    .limit(1)
    .run(&client)
    .await?
    .into_iter()
    .nth(0)
    .ok_or(Error::msg("Not found"))
```
