### PR TITLE
Optionally emit tracing events for database errors

### DIFF
--- a/welds-connections/Cargo.toml
+++ b/welds-connections/Cargo.toml
@@ -24,6 +24,7 @@ description = "An async ORM for (postgres, mssql, mysql, sqlite)"
 "mssql-rust_decimal" = ["tiberius/rust_decimal"]
 "mssql-bigdecimal" = ["tiberius/bigdecimal"]
 "noop" = []
+"tracing" = ["dep:tracing"]
 "full" = ["postgres", "mysql", "sqlite", "mssql", "noop"]
 
 

--- a/welds-connections/src/lib.rs
+++ b/welds-connections/src/lib.rs
@@ -6,7 +6,7 @@ pub use transaction::Transaction;
 pub mod errors;
 pub mod row;
 pub mod transaction;
-
+pub mod trace;
 pub mod any;
 #[cfg(feature = "mssql")]
 pub mod mssql;

--- a/welds-connections/src/mysql/mod.rs
+++ b/welds-connections/src/mysql/mod.rs
@@ -1,5 +1,5 @@
 use super::transaction::{TransT, Transaction};
-use super::Row;
+use super::{trace, Row};
 use super::TransactStart;
 use super::{Client, Param};
 use crate::errors::Result;
@@ -55,7 +55,7 @@ impl Client for MysqlClient {
         for param in params {
             query = MysqlParam::add_param(*param, query);
         }
-        let r = query.execute(&*self.pool).await?;
+        let r = trace::db_error(query.execute(&*self.pool).await)?;
         Ok(ExecuteResult {
             rows_affected: r.rows_affected(),
         })
@@ -67,7 +67,7 @@ impl Client for MysqlClient {
         for param in params {
             query = MysqlParam::add_param(*param, query);
         }
-        let mut raw_rows = query.fetch_all(&*self.pool).await?;
+        let mut raw_rows = trace::db_error(query.fetch_all(&*self.pool).await)?;
         let rows: Vec<Row> = raw_rows.drain(..).map(Row::from).collect();
         Ok(rows)
     }
@@ -86,7 +86,7 @@ impl Client for MysqlClient {
             for param in params {
                 query = MysqlParam::add_param(*param, query);
             }
-            let mut raw_rows = query.fetch_all(&mut *conn).await?;
+            let mut raw_rows = trace::db_error(query.fetch_all(&mut *conn).await)?;
             let rows: Vec<Row> = raw_rows.drain(..).map(Row::from).collect();
             datasets.push(rows);
         }

--- a/welds-connections/src/postgres/mod.rs
+++ b/welds-connections/src/postgres/mod.rs
@@ -1,5 +1,5 @@
 use super::transaction::{TransT, Transaction};
-use super::Row;
+use super::{trace, Row};
 use super::TransactStart;
 use super::{Client, Param};
 use crate::errors::Result;
@@ -56,7 +56,7 @@ impl Client for PostgresClient {
         for param in params {
             query = PostgresParam::add_param(*param, query);
         }
-        let r = query.execute(&*self.pool).await?;
+        let r = trace::db_error(query.execute(&*self.pool).await)?;
         Ok(ExecuteResult {
             rows_affected: r.rows_affected(),
         })
@@ -68,7 +68,7 @@ impl Client for PostgresClient {
         for param in params {
             query = PostgresParam::add_param(*param, query);
         }
-        let mut raw_rows = query.fetch_all(&*self.pool).await?;
+        let mut raw_rows = trace::db_error(query.fetch_all(&*self.pool).await)?;
         let rows: Vec<Row> = raw_rows.drain(..).map(Row::from).collect();
         Ok(rows)
     }
@@ -87,7 +87,7 @@ impl Client for PostgresClient {
             for param in params {
                 query = PostgresParam::add_param(*param, query);
             }
-            let mut raw_rows = query.fetch_all(&mut *conn).await?;
+            let mut raw_rows = trace::db_error(query.fetch_all(&mut *conn).await)?;
             let rows: Vec<Row> = raw_rows.drain(..).map(Row::from).collect();
             datasets.push(rows);
         }

--- a/welds-connections/src/trace.rs
+++ b/welds-connections/src/trace.rs
@@ -1,0 +1,15 @@
+use crate::errors;
+#[cfg(feature = "tracing")]
+use tracing;
+
+/// Emits an event when an error is returned from the client, if the "tracing" feature
+/// is enabled and a corresponding tracing-subscriber is registered, otherwise no-op
+pub fn db_error<T>(result: Result<T, sqlx::Error>) -> Result<T, sqlx::Error> {
+    #[cfg(feature = "tracing")]
+    if let Err(e) = result {
+        tracing::warn!("Database Error; {}", e);
+        return Err(e)
+    }
+
+    result
+}

--- a/welds/Cargo.toml
+++ b/welds/Cargo.toml
@@ -30,6 +30,7 @@ welds-macros = { path="../welds-macros", version = "^0.4.12" }
 "mock" = []
 "check" = ["detect", "colored"]
 "migrations" = ["detect"]
+"tracing" = ["welds-connections/tracing"]
 
 
 #[profile.dev.package.sqlx-macros]


### PR DESCRIPTION
Proposal/PR: optionally emit a tracing event when a database error is returned from the client when executing queries.

Useful in dev, but potentially also useful in production environments (depending on the application) for increased visibility around database errors?

I've put it behind a feature flag, and the tracing events only get emitted if a tracing subscriber is registered at runtime, otherwise it's a no-op.

What do you think?