### PR TITLE
fix: dataset filtering with two relationships to the same model

### DIFF
--- a/tests/mssql/src/models/order/definition.rs
+++ b/tests/mssql/src/models/order/definition.rs
@@ -7,7 +7,7 @@ use welds::WeldsModel;
 #[derive(Debug, WeldsModel)]
 #[welds(schema = "welds", table = "Orders")]
 #[welds(BelongsTo(product, super::super::product::Product, "product_id"))]
-#[welds(BelongsTo(product2, super::super::product::Product, "product_id_2"))]
+#[welds(BelongsTo(product2, super::super::product::Product, "product_id2"))]
 pub struct Order {
     #[welds(primary_key)]
     pub id: i32,

--- a/tests/mssql/tests/all_tests.rs
+++ b/tests/mssql/tests/all_tests.rs
@@ -333,7 +333,16 @@ async fn should_be_able_to_write_a_custom_set() {
         .map_query(|p| p.order)
         .where_col(|c| c.id.equal(2342534))
         .set_manual(|x| x.product_id, "product_id + ?", params);
-    let sql = q.to_sql(Syntax::Postgres);
+    let sql = q.to_sql(Syntax::Mssql);
+    eprintln!("SQL: {}", sql);
+    q.run(&conn).await.unwrap();
+}
+
+#[tokio::test]
+async fn should_be_able_to_write_mapquery_with_a_column_rename() {
+    let conn = get_conn().await;
+    let q = Order::all().map_query(|o| o.product2);
+    let sql = q.to_sql(Syntax::Mssql);
     eprintln!("SQL: {}", sql);
     q.run(&conn).await.unwrap();
 }

--- a/tests/sqlite/tests/includes/mod.rs
+++ b/tests/sqlite/tests/includes/mod.rs
@@ -199,20 +199,11 @@ fn should_return_borrowed_objects_from_iterator() {
     async_std::task::block_on(async {
         let conn = get_conn().await;
 
-        let dataset = Team::all()
-            .include(|x| x.players)
-            .run(&conn)
-            .await
-            .unwrap();
+        let dataset = Team::all().include(|x| x.players).run(&conn).await.unwrap();
 
         let output = dataset
             .iter()
-            .map(|data| {
-                (
-                    data.as_ref(),
-                    data.get(|x| x.players)
-                )
-            })
+            .map(|data| (data.as_ref(), data.get(|x| x.players)))
             .collect::<Vec<(&Team, Vec<&Player>)>>();
 
         assert_eq!(output[0].0.id, 1)
@@ -224,20 +215,11 @@ fn should_return_owned_objects_from_iterator() {
     async_std::task::block_on(async {
         let conn = get_conn().await;
 
-        let dataset = Team::all()
-            .include(|x| x.players)
-            .run(&conn)
-            .await
-            .unwrap();
+        let dataset = Team::all().include(|x| x.players).run(&conn).await.unwrap();
 
         let output = dataset
             .iter()
-            .map(|data| {
-                (
-                    data.clone(),
-                    data.get_owned(|x| x.players)
-                )
-            })
+            .map(|data| (data.clone(), data.get_owned(|x| x.players)))
             .collect::<Vec<(Team, Vec<Player>)>>();
 
         assert_eq!(output[0].0.id, 1)

--- a/welds-macros/src/attributes.rs
+++ b/welds-macros/src/attributes.rs
@@ -31,7 +31,6 @@ pub(crate) fn get_columns(ast: &syn::DeriveInput) -> Vec<Column> {
                 ignore,
                 dbname,
                 field_type,
-                full_field_type: f.ty.clone(),
                 is_option,
             }
         })
@@ -62,7 +61,6 @@ pub(crate) fn get_pks(ast: &syn::DeriveInput) -> Vec<Column> {
                 ignore: false,
                 dbname,
                 field_type,
-                full_field_type: f.ty.clone(),
                 is_option,
             }
         })

--- a/welds-macros/src/blocks/foreign_key_partial_eq.rs
+++ b/welds-macros/src/blocks/foreign_key_partial_eq.rs
@@ -31,19 +31,21 @@ pub(crate) fn write(info: &Info) -> TokenStream {
         .filter_map(|fkname| info.columns.iter().find(|c| &c.dbname == fkname))
         .collect();
 
-    // find all the unique types that we need to support
-    let fk_types: HashSet<Type> = fks.iter().map(|x| x.full_type()).collect();
+    // build a list of all external types we want to be able to compare to
+    let fk_types: HashSet<Type> = fks.iter().map(|x| x.field_type.clone()).collect();
 
     let mut implementations: Vec<TokenStream> = Vec::default();
     for fk_type in fk_types {
-        // find all the fks we are about to write an impl for
+        // find all the fks Columns that will be in the match for this type.
         let impl_for_fk: Vec<&Column> = fks
             .iter()
             .cloned()
-            .filter(|x| x.full_type().eq(&fk_type))
+            .filter(|x| x.field_type.eq(&fk_type))
             .collect();
-        // writes the impl
-        implementations.push(impl_for_type(fk_type, impl_for_fk, info));
+
+        // writes the impl for basic and optional variants of the type
+        implementations.push(impl_for_type_non_opt(fk_type.clone(), &impl_for_fk, info));
+        implementations.push(impl_for_type_opt(fk_type.clone(), &impl_for_fk, info));
     }
 
     quote! {
@@ -51,28 +53,15 @@ pub(crate) fn write(info: &Info) -> TokenStream {
     }
 }
 
-/* Example Impl
-impl ForeignKeyPartialEq<i32> for Order {
-    fn eq(&self, foreign_key_field: &str, other: &i32) -> bool {
-        match foreign_key_field {
-            "product_id" => self.product_id.eq(other),
-            //"product_id" => return other == self.product_id,
-            _ => false,
-        }
-    }
-}
-*/
-
-fn impl_for_type(ty: Type, fks: Vec<&Column>, info: &Info) -> TokenStream {
+fn impl_for_type_opt(other_ty: Type, fks: &[&Column], info: &Info) -> TokenStream {
     let defstruct = &info.defstruct;
     let wp = &info.welds_path;
-    let matchers: Vec<TokenStream> = fks.iter().cloned().map(write_matcher).collect();
+    let matchers: Vec<TokenStream> = fks.iter().cloned().map(write_option_matcher).collect();
     let matchers = quote! { #(#matchers)* };
     quote! {
-        impl #wp::model_traits::ForeignKeyPartialEq<#ty> for #defstruct {
-            fn eq(&self, foreign_key_field: &str, other: &#ty) -> bool {
+        impl #wp::model_traits::ForeignKeyPartialEq<Option<#other_ty>> for #defstruct {
+            fn eq(&self, foreign_key_field: &str, other: &Option<#other_ty>) -> bool {
                 match foreign_key_field {
-                    //"product_id" => self.product_id.eq(other),
                     #matchers
                     _ => false,
                 }
@@ -81,8 +70,43 @@ fn impl_for_type(ty: Type, fks: Vec<&Column>, info: &Info) -> TokenStream {
     }
 }
 
-fn write_matcher(col: &Column) -> TokenStream {
+fn impl_for_type_non_opt(other_ty: Type, fks: &[&Column], info: &Info) -> TokenStream {
+    let defstruct = &info.defstruct;
+    let wp = &info.welds_path;
+    let matchers: Vec<TokenStream> = fks.iter().cloned().map(write_basic_matcher).collect();
+    let matchers = quote! { #(#matchers)* };
+    quote! {
+        impl #wp::model_traits::ForeignKeyPartialEq<#other_ty> for #defstruct {
+            fn eq(&self, foreign_key_field: &str, other: &#other_ty) -> bool {
+                match foreign_key_field {
+                    #matchers
+                    _ => false,
+                }
+            }
+        }
+    }
+}
+
+fn write_basic_matcher(col: &Column) -> TokenStream {
+    // Other is NOT option.
+    // self.field COULD be option
     let fkname = &col.dbname;
     let field = &col.field;
-    quote! { #fkname => self.#field.eq(other), }
+    if col.is_option {
+        quote! { #fkname => if self.#field.is_none() { false } else { self.#field.as_ref().unwrap().eq(other) }  }
+    } else {
+        quote! { #fkname => self.#field.eq(other), }
+    }
+}
+
+fn write_option_matcher(col: &Column) -> TokenStream {
+    // Other IS option
+    // self.field COULD be option
+    let fkname = &col.dbname;
+    let field = &col.field;
+    if col.is_option {
+        quote! { #fkname => self.#field.eq(other), }
+    } else {
+        quote! { #fkname => if other.is_none() { false } else { self.#field.eq(other.as_ref().unwrap()) }  }
+    }
 }

--- a/welds-macros/src/blocks/relations.rs
+++ b/welds-macros/src/blocks/relations.rs
@@ -16,17 +16,10 @@ pub(crate) fn write(info: &Info) -> TokenStream {
     let default_fields: Vec<_> = relations.iter().map(|x| defaultdef(info, x)).collect();
     let default_fields = quote! { #(#default_fields), * };
 
-    // we define a impl RelationValue<_> for each Relationship defined on the struct
-    // [#welds(HasMany, .., ..)]
-    let relation_value_impl: Vec<_> = relations
-        .iter()
-        .map(|x| relation_value_def(info, x))
-        .collect();
-    let relation_value_impl = quote! { #(#relation_value_impl) * };
+    // panic when code is invalid to give nice errors
+    compiletime_asserts(info);
 
     quote! {
-
-        #relation_value_impl
 
         // build the HasRelations struct used for lambda selection of relationships
         impl #wp::relations::HasRelations for #defstruct {
@@ -42,23 +35,6 @@ pub(crate) fn write(info: &Info) -> TokenStream {
                 Self {
                     #default_fields
                 }
-            }
-        }
-
-        impl #wp::model_traits::CheckRelationship for #defstruct {
-            fn check<R>(&self, other: &R) -> bool
-            where
-                R: #wp::relations::RelationValue<Self>,
-                Self: #wp::relations::RelationValue<R>,
-            {
-                let self_value = <Self as #wp::relations::RelationValue<R>>::relation_value(self);
-                let other_value = <R as #wp::relations::RelationValue<Self>>::relation_value(other);
-
-                if let Some(downcast_other_value) = (&other_value as &dyn std::any::Any).downcast_ref::<<Self as #wp::relations::RelationValue<R>>::ValueType>() {
-                    return &self_value == downcast_other_value
-                }
-
-                false
             }
         }
 
@@ -87,84 +63,50 @@ fn defaultdef(info: &Info, relation: &Relation) -> TokenStream {
     }
 }
 
-// writes impl RelationValue for a given Relation
-fn relation_value_def(info: &Info, relation: &Relation) -> TokenStream {
-    let kind = &relation.kind;
-
-    // first we need to see if the FK is on this table other the other table.
-    // That way we know where to get the value we are looking for
-    let kind_name = kind.to_string();
-    let fk_on_other = &kind_name == "HasOne" || &kind_name == "BelongsTo";
-
-    if fk_on_other {
-        relation_value_def_from_fk(info, relation)
-    } else {
-        relation_value_def_from_pk(info, relation)
-    }
-}
-
-// writes impl RelationValue for a given Relation
-// Reading the value from a foreign_key field
-fn relation_value_def_from_fk(info: &Info, relation: &Relation) -> TokenStream {
-    let wp = &info.welds_path;
-    let cols = &info.columns;
-    //let kind = &relation.kind;
+/// check that the Relation and columns are defined correctly.
+/// If not will panic to give a compile time error for the user.
+fn compiletime_asserts(info: &Info) {
+    let columns = &info.columns;
+    let relations = info.relations.as_slice();
     let defstruct = &info.defstruct;
-    let other = &relation.foreign_struct;
-    let fk = &relation.foreign_key_rust;
 
-    let fk_col = cols.iter().find(|x| x.field == fk);
-    // If the fk column is missing, panic to give a compile time error.
-    // The user has defined a relationship that points to a rust field that doesn't exist.
-    let fk_column = fk_col.unwrap_or_else(|| panic!("The model {} is missing the field {}. This field was expected because it was defined in a Welds Relationship", defstruct, fk));
-
-    // build the inner content that reads the field.
-    let fk_name = &fk_column.field;
-    let fk_type = &fk_column.field_type;
-    let fk_value_inner = if fk_column.is_option {
-        quote! { self.#fk_name.clone().unwrap_or_default() }
-    } else {
-        quote! { self.#fk_name.clone() }
-    };
-
-    quote! {
-        impl #wp::relations::RelationValue<#other> for #defstruct {
-            type ValueType = #fk_type;
-            fn relation_value(&self) -> Self::ValueType
-            where
-                <Self as #wp::model_traits::HasSchema>::Schema: #wp::model_traits::TableInfo + #wp::model_traits::TableColumns,
-            {
-                #fk_value_inner
-            }
+    for relation in relations {
+        let relation_kind_name = relation.kind.to_string();
+        // Compile time check that the column exists.
+        if &relation_kind_name == "BelongsTo" {
+            let found = columns.iter().find(|x| x.dbname == relation.foreign_key_db);
+            assert!(
+                found.is_some(),
+                "The model {} has a BelongsTo relationships pointing to the Foreign key {}, but this column is not defined on the model",
+                defstruct,
+                relation.foreign_key_db
+            );
         }
-    }
-}
-
-// writes impl RelationValue for a given Relation
-// Reading the value from the primary_key field
-fn relation_value_def_from_pk(info: &Info, relation: &Relation) -> TokenStream {
-    let wp = &info.welds_path;
-    let other = &relation.foreign_struct;
-    let defstruct = &info.defstruct;
-    // If the model doesn't have a primary_key, panic to give the user a compile time error
-    // The user has defined a relationship that points to a rust field that doesn't exist.
-    let pk_column = info.pks.first();
-    let pk_column = pk_column.unwrap_or_else(|| panic!("The model {} is missing a primary key. This field was expected because it was defined in a Welds Relationship", defstruct));
-
-    let pk_name = &pk_column.field;
-    let pk_type = &pk_column.field_type;
-
-    quote! {
-
-        impl #wp::relations::RelationValue<#other> for #defstruct {
-            type ValueType = #pk_type;
-            fn relation_value(&self) -> Self::ValueType
-            where
-                <Self as #wp::model_traits::HasSchema>::Schema: #wp::model_traits::TableInfo + #wp::model_traits::TableColumns,
-            {
-                self.#pk_name.clone()
-            }
+        // Compile time check that the pk column exists.
+        if &relation_kind_name == "HasMany" {
+            assert!(
+                !info.pks.is_empty(),
+                "The model {} has a HasMany relationships defined, but no primary_key column is defined",
+                defstruct,
+            );
         }
-
+        // Compile time check that the pk column exists.
+        if &relation_kind_name == "BelongsToOne" {
+            assert!(
+                !info.pks.is_empty(),
+                "The model {} has a BelongsToOne relationships defined, but no primary_key column is defined",
+                defstruct,
+            );
+        }
+        // Compile time check that the column exists.
+        if &relation_kind_name == "HasOne" {
+            let found = columns.iter().find(|x| x.dbname == relation.foreign_key_db);
+            assert!(
+                found.is_some(),
+                "The model {} has a HasOne relationships pointing to the Foreign key {}, but this column is not defined on the model",
+                defstruct,
+                relation.foreign_key_db
+            );
+        }
     }
 }

--- a/welds-macros/src/column.rs
+++ b/welds-macros/src/column.rs
@@ -7,14 +7,5 @@ pub(crate) struct Column {
     pub(crate) ignore: bool,
     pub(crate) dbname: String,
     pub(crate) field_type: Type,
-    pub(crate) full_field_type: Type,
     pub(crate) is_option: bool,
-}
-
-impl Column {
-    // returns the full type of the column
-    // including the wrapping Option.
-    pub(crate) fn full_type(&self) -> Type {
-        self.full_field_type.clone()
-    }
 }

--- a/welds-macros/src/info.rs
+++ b/welds-macros/src/info.rs
@@ -95,7 +95,6 @@ mod tests {
                 field,
                 ignore: false,
                 dbname: name,
-                full_field_type: field_type.clone(),
                 field_type,
                 is_option: null,
             };
@@ -113,7 +112,6 @@ mod tests {
                 field,
                 ignore: false,
                 dbname: name,
-                full_field_type: field_type.clone(),
                 field_type,
                 is_option: false,
             };

--- a/welds-macros/src/lib.rs
+++ b/welds-macros/src/lib.rs
@@ -40,7 +40,7 @@ fn model_gen_inner(input: TokenStream) -> errors::Result<TokenStream> {
     let p12 = blocks::write_col_default_check(&info);
     let p13 = blocks::write_hooks(&info);
     let p14 = blocks::write_primary_key_value(&info);
-    //let p15 = blocks::foreign_key_partial_eq(&info);
+    let p15 = blocks::foreign_key_partial_eq(&info);
 
     let q = quote! {
         #p1
@@ -57,18 +57,18 @@ fn model_gen_inner(input: TokenStream) -> errors::Result<TokenStream> {
         #p12
         #p13
         #p14
-        //#p15
+        #p15
     };
 
-    //  // Want to see what the macros generate?
-    //  // this works, or `rustaceanvim :RustLsp expandMacro`
-    //  let code = q.to_string();
-    //  std::fs::create_dir_all("/tmp/weldsmacro/");
-    //  let filename = format!(
-    //      "/tmp/weldsmacro/{}.rs",
-    //      info.defstruct.to_string().to_lowercase()
-    //  );
-    //  std::fs::write(filename, code);
+    // // Want to see what the macros generate?
+    // // this works, or `rustaceanvim :RustLsp expandMacro`
+    // let code = q.to_string();
+    // std::fs::create_dir_all("/tmp/weldsmacro/");
+    // let filename = format!(
+    //     "/tmp/weldsmacro/{}.rs",
+    //     info.defstruct.to_string().to_lowercase()
+    // );
+    // std::fs::write(filename, code);
 
     Ok(q.into())
 }

--- a/welds-macros/src/relation.rs
+++ b/welds-macros/src/relation.rs
@@ -7,8 +7,6 @@ pub(crate) struct Relation {
     pub(crate) kind: Ident,
     pub(crate) field: Ident,
     pub(crate) foreign_struct: syn::Path,
-    // the field name of the FK in rust
-    pub(crate) foreign_key_rust: String,
     // the field name of the FK in the DB
     pub(crate) foreign_key_db: String,
 }
@@ -65,7 +63,6 @@ impl Relation {
             kind,
             field,
             foreign_struct: model.clone(),
-            foreign_key_rust: foreign_key.clone(),
             foreign_key_db: foreign_key.clone(),
         })
     }

--- a/welds/src/migrations/tablemod/tests.rs
+++ b/welds/src/migrations/tablemod/tests.rs
@@ -1,6 +1,5 @@
 use super::*;
 use crate::detect::table_def::mock::MockTableDef;
-use crate::migrations::types::Type;
 use crate::migrations::MigrationWriter;
 use crate::Syntax;
 

--- a/welds/src/model_traits/mod.rs
+++ b/welds/src/model_traits/mod.rs
@@ -1,5 +1,3 @@
-use crate::relations::RelationValue;
-
 /// ***********************************************************************************
 /// These are all the trait and struct used to connect a rust Struct to a database driver
 /// ***********************************************************************************
@@ -88,16 +86,6 @@ pub trait HasSchema: Sync + Send {
     type Schema: Default + TableInfo;
 }
 
-/// used to compare two models and see if a relationship holds
-pub trait CheckRelationship {
-    /// returns true if a relations holds between two objects
-    fn check<R>(&self, other: &R) -> bool
-    where
-        R: RelationValue<Self>,
-        Self: RelationValue<R>,
-        Self: Sized;
-}
-
 /// Returns the Value of the PK of a model
 pub trait PrimaryKeyValue {
     type PrimaryKeyType;
@@ -105,12 +93,12 @@ pub trait PrimaryKeyValue {
     fn primary_key_value(&self) -> Self::PrimaryKeyType;
 }
 
-//  /// Used to check if a Foreign Key is equal to a value
-//  pub trait ForeignKeyPartialEq<Rhs> {
-//      /// return true if the Foreign Key value equals the passed in value
-//      /// false if the values don't match OR object doesn't have the field
-//      fn eq(&self, foreign_key_field: &str, other: &Rhs) -> bool;
-//  }
+/// Used to check if a Foreign Key is equal to a value
+pub trait ForeignKeyPartialEq<Rhs> {
+    /// return true if the Foreign Key value equals the passed in value
+    /// false if the values don't match OR object doesn't have the column
+    fn eq(&self, foreign_key_column: &str, other: &Rhs) -> bool;
+}
 
 mod tableident;
 pub use tableident::TableIdent;

--- a/welds/src/model_traits/tests.rs
+++ b/welds/src/model_traits/tests.rs
@@ -3,7 +3,7 @@ use crate::WeldsModel;
 #[derive(Debug, Default, WeldsModel)]
 #[welds(table = "products")]
 #[welds_path(crate)] // needed only within the welds crate.
-#[welds(HasMany(orders, Order, "product_id"))]
+#[welds(HasMany(orders, OrderA, "product_id"))]
 struct Product {
     #[welds(primary_key)]
     pub id: i32,
@@ -13,7 +13,7 @@ struct Product {
 #[derive(Debug, Default, WeldsModel)]
 #[welds(table = "buyers")]
 #[welds_path(crate)] // needed only within the welds crate.
-#[welds(HasMany(orders, Order, "buyer_id"))]
+#[welds(HasMany(orders, OrderA, "buyer_id"))]
 struct Buyer {
     #[welds(primary_key)]
     pub id: String,
@@ -25,12 +25,24 @@ struct Buyer {
 #[welds_path(crate)] // needed only within the welds crate.
 #[welds(BelongsTo(product, Product, "product_id"))]
 #[welds(BelongsTo(buyer, Buyer, "buyer_id"))]
-struct Order {
+struct OrderA {
     #[welds(primary_key)]
     pub id: i32,
     pub product_id: i32,
     pub buyer_id: String,
     pub price: i32,
+}
+
+#[derive(Debug, Default, WeldsModel)]
+#[welds(table = "orders")]
+#[welds_path(crate)] // needed only within the welds crate.
+#[welds(BelongsTo(product, Product, "product_id"))]
+#[welds(BelongsTo(product2, Product, "product_id2"))]
+struct OrderB {
+    #[welds(primary_key)]
+    pub id: i32,
+    pub product_id: Option<i32>,
+    pub product_id2: i32,
 }
 
 // use crate::model_traits::CheckRelationship;
@@ -95,26 +107,39 @@ fn should_be_able_to_read_the_pk() {
     });
 }
 
-// #[test]
-// fn should_be_able_to_equal_fks() {
-//     futures::executor::block_on(async move {
-//         let order = Order {
-//             id: 33,
-//             product_id: 234,
-//             buyer_id: "B1".to_string(),
-//             price: 11,
-//         };
-//         assert!(!super::ForeignKeyPartialEq::eq(&order, "product_id", &2),);
-//         assert!(super::ForeignKeyPartialEq::eq(&order, "product_id", &234),);
-//         assert!(!super::ForeignKeyPartialEq::eq(
-//             &order,
-//             "buyer_id",
-//             &"B2".to_string()
-//         ),);
-//         assert!(super::ForeignKeyPartialEq::eq(
-//             &order,
-//             "buyer_id",
-//             &"B1".to_string()
-//         ),);
-//     });
-// }
+#[test]
+fn should_be_able_to_equal_fks() {
+    futures::executor::block_on(async move {
+        let order = OrderA {
+            id: 33,
+            product_id: 234,
+            buyer_id: "B1".to_string(),
+            price: 11,
+        };
+        assert!(!super::ForeignKeyPartialEq::eq(&order, "product_id", &2),);
+        assert!(super::ForeignKeyPartialEq::eq(&order, "product_id", &234),);
+        assert!(!super::ForeignKeyPartialEq::eq(
+            &order,
+            "buyer_id",
+            &"B2".to_string()
+        ),);
+        assert!(super::ForeignKeyPartialEq::eq(
+            &order,
+            "buyer_id",
+            &"B1".to_string()
+        ),);
+    });
+}
+
+#[test]
+fn should_be_able_to_equal_fks_optional() {
+    futures::executor::block_on(async move {
+        let order2 = OrderB {
+            id: 33,
+            product_id: Some(234),
+            product_id2: 234,
+        };
+        assert!(super::ForeignKeyPartialEq::eq(&order2, "product_id", &234));
+        assert!(super::ForeignKeyPartialEq::eq(&order2, "product_id2", &234));
+    });
+}

--- a/welds/src/query/builder/mod.rs
+++ b/welds/src/query/builder/mod.rs
@@ -16,6 +16,9 @@ pub use super::clause::manualparam::ManualParam;
 #[deprecated(note = "please use `ManualParam` instead")]
 pub type ManualWhereParam = ManualParam;
 
+#[cfg(test)]
+mod tests;
+
 /// An un-executed Query.
 ///
 /// Build out a query that can be executed on the database.

--- a/welds/src/query/builder/tests.rs
+++ b/welds/src/query/builder/tests.rs
@@ -1,0 +1,44 @@
+use crate::WeldsModel;
+use welds_connections::Syntax;
+
+#[derive(Debug, Default, WeldsModel)]
+#[welds(table = "products")]
+#[welds_path(crate)] // needed only within the welds crate.
+#[welds(HasMany(orders, OrderC, "product_id"))]
+struct ProductC {
+    #[welds(primary_key)]
+    pub pid: i32,
+    pub name: String,
+}
+
+#[derive(Debug, Default, WeldsModel)]
+#[welds(table = "orders")]
+#[welds_path(crate)] // needed only within the welds crate.
+#[welds(BelongsTo(product, ProductC, "product_id"))]
+struct OrderC {
+    #[welds(primary_key)]
+    pub id: i32,
+    #[welds(rename = "product_id")]
+    pub prod_id: i32,
+    pub price: i32,
+}
+
+#[test]
+fn should_be_able_to_map_query_from_belongs_to() {
+    futures::executor::block_on(async move {
+        let q = ProductC::all().map_query(|p| p.orders);
+        let sql = q.to_sql(Syntax::Mssql);
+        let valid = r#"SELECT t2."id", t2."product_id", t2."price" FROM orders t2 WHERE ( EXISTS ( SELECT pid FROM products t1 WHERE t1.pid = t2.product_id ) )"#;
+        assert_eq!(sql, valid);
+    });
+}
+
+#[test]
+fn should_be_able_to_map_query_from_has_many() {
+    futures::executor::block_on(async move {
+        let q = OrderC::all().map_query(|p| p.product);
+        let sql = q.to_sql(Syntax::Mssql);
+        let valid = r#"SELECT t2."pid", t2."name" FROM products t2 WHERE ( EXISTS ( SELECT product_id FROM orders t1 WHERE t1.product_id = t2.pid ) )"#;
+        assert_eq!(sql, valid);
+    });
+}

--- a/welds/src/query/delete/tests.rs
+++ b/welds/src/query/delete/tests.rs
@@ -1,6 +1,5 @@
 use crate::state::DbState;
 use crate::Syntax;
-use welds_connections::Row;
 
 // Testing that the tail end of the SQL is correct
 // Limits / skips / orders

--- a/welds/src/query/include/related_query.rs
+++ b/welds/src/query/include/related_query.rs
@@ -1,11 +1,11 @@
 use crate::connections::Row;
 use crate::errors::Result;
 use crate::errors::WeldsError;
+use crate::exts::VecStateExt;
 use crate::model_traits::{HasSchema, TableColumns, TableInfo, UniqueIdentifier};
 use crate::query::builder::QueryBuilder;
 use crate::query::clause::exists::ExistIn;
 use crate::relations::Relationship;
-use crate::exts::VecStateExt;
 use crate::Client;
 use async_trait::async_trait;
 use std::any::Any;
@@ -80,7 +80,7 @@ where
 
 pub(crate) trait RelatedSetAccesser {
     fn as_any(&self) -> &dyn Any;
-    fn as_any_mut(&mut self) -> &mut dyn Any;
+    //fn as_any_mut(&mut self) -> &mut dyn Any;
 }
 
 impl<R: 'static, Ship: 'static> RelatedSetAccesser for RelatedSet<R, Ship>
@@ -91,18 +91,18 @@ where
         self
     }
 
-    fn as_any_mut(&mut self) -> &mut dyn Any {
-        self
-    }
+    //fn as_any_mut(&mut self) -> &mut dyn Any {
+    //    self
+    //}
 }
 
 pub(crate) trait SetDowncast {
     fn downcast_ref<R: 'static, Ship: 'static + Relationship<R>>(
         &self,
     ) -> Option<&RelatedSet<R, Ship>>;
-    fn downcast_mut<R: 'static, Ship: 'static + Relationship<R>>(
-        &mut self,
-    ) -> Option<&mut RelatedSet<R, Ship>>;
+    // fn downcast_mut<R: 'static, Ship: 'static + Relationship<R>>(
+    //     &mut self,
+    // ) -> Option<&mut RelatedSet<R, Ship>>;
 }
 
 impl SetDowncast for Box<dyn RelatedSetAccesser + Send> {
@@ -112,9 +112,9 @@ impl SetDowncast for Box<dyn RelatedSetAccesser + Send> {
         self.as_any().downcast_ref::<RelatedSet<R, Ship>>()
     }
 
-    fn downcast_mut<R: 'static, Ship: 'static + Relationship<R>>(
-        &mut self,
-    ) -> Option<&mut RelatedSet<R, Ship>> {
-        self.as_any_mut().downcast_mut::<RelatedSet<R, Ship>>()
-    }
+    // fn downcast_mut<R: 'static, Ship: 'static + Relationship<R>>(
+    //     &mut self,
+    // ) -> Option<&mut RelatedSet<R, Ship>> {
+    //     self.as_any_mut().downcast_mut::<RelatedSet<R, Ship>>()
+    // }
 }

--- a/welds/src/query/include/tests.rs
+++ b/welds/src/query/include/tests.rs
@@ -1,4 +1,3 @@
-use crate::Syntax;
 use crate::WeldsModel;
 
 #[derive(Debug, Default, WeldsModel)]
@@ -25,6 +24,6 @@ struct Order {
 #[test]
 fn should_be_able_to_build_a_query_including_both_objects() {
     futures::executor::block_on(async move {
-        let q = Product::all().include(|p| p.orders);
+        let _q = Product::all().include(|p| p.orders);
     });
 }

--- a/welds/src/query/insert/single/tests.rs
+++ b/welds/src/query/insert/single/tests.rs
@@ -1,6 +1,5 @@
 use crate::state::DbState;
 use crate::Syntax;
-use welds_connections::Row;
 
 // Testing that the tail end of the SQL is correct
 // Limits / skips / orders

--- a/welds/src/query/select/tests/basicopt.rs
+++ b/welds/src/query/select/tests/basicopt.rs
@@ -17,7 +17,7 @@ struct Product2 {
 
 impl TryFrom<Row> for Product2 {
     type Error = crate::WeldsError;
-    fn try_from(value: Row) -> std::result::Result<Self, Self::Error> {
+    fn try_from(_value: Row) -> std::result::Result<Self, Self::Error> {
         Ok(Product2 { name: None })
     }
 }

--- a/welds/src/query/select/tests/sql_tails.rs
+++ b/welds/src/query/select/tests/sql_tails.rs
@@ -16,7 +16,7 @@ struct Product {
 
 impl TryFrom<Row> for Product {
     type Error = crate::WeldsError;
-    fn try_from(value: Row) -> std::result::Result<Self, Self::Error> {
+    fn try_from(_value: Row) -> std::result::Result<Self, Self::Error> {
         Ok(Product { a: 0, b: 0 })
     }
 }

--- a/welds/src/query/update/single/tests.rs
+++ b/welds/src/query/update/single/tests.rs
@@ -1,6 +1,5 @@
 use crate::state::DbState;
 use crate::Syntax;
-use welds_connections::Row;
 
 // Testing that the tail end of the SQL is correct
 // Limits / skips / orders

--- a/welds/src/relations/belongsto.rs
+++ b/welds/src/relations/belongsto.rs
@@ -1,0 +1,69 @@
+use super::Relationship;
+use super::RelationshipCompare;
+use crate::model_traits::ForeignKeyPartialEq;
+use crate::model_traits::HasSchema;
+use crate::model_traits::PrimaryKeyValue;
+use crate::model_traits::UniqueIdentifier;
+use std::marker::PhantomData;
+
+pub struct BelongsTo<T> {
+    _t: PhantomData<T>,
+    foreign_key: &'static str,
+}
+
+impl<T> BelongsTo<T> {
+    pub fn using(fk: &'static str) -> BelongsTo<T> {
+        BelongsTo {
+            _t: Default::default(),
+            foreign_key: fk,
+        }
+    }
+}
+
+// writing these by hand to ignore PhantomData
+impl<T> PartialEq for BelongsTo<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.foreign_key == other.foreign_key
+    }
+}
+impl<T> Clone for BelongsTo<T> {
+    fn clone(&self) -> Self {
+        Self {
+            _t: Default::default(),
+            foreign_key: self.foreign_key,
+        }
+    }
+}
+
+impl<R: Send> Relationship<R> for BelongsTo<R> {
+    fn my_key<ME, THEM>(&self) -> String
+    where
+        ME: UniqueIdentifier,
+        THEM: UniqueIdentifier,
+    {
+        self.foreign_key.to_owned()
+    }
+    fn their_key<ME, THEM>(&self) -> String
+    where
+        ME: UniqueIdentifier,
+        THEM: UniqueIdentifier,
+    {
+        ME::id_column().name().to_owned()
+    }
+}
+
+impl<T, R> RelationshipCompare<T, R> for BelongsTo<R>
+where
+    Self: Relationship<R>,
+    R: PrimaryKeyValue + HasSchema,
+    R::Schema: UniqueIdentifier,
+    T: HasSchema,
+    T::Schema: UniqueIdentifier,
+    T: ForeignKeyPartialEq<R::PrimaryKeyType>,
+{
+    fn is_related(&self, source: &T, other: &R) -> bool {
+        let pk = other.primary_key_value();
+        let fk_field: String = Self::my_key::<R::Schema, T::Schema>(self);
+        source.eq(&fk_field, &pk)
+    }
+}

--- a/welds/src/relations/belongstoone.rs
+++ b/welds/src/relations/belongstoone.rs
@@ -1,0 +1,69 @@
+use super::Relationship;
+use super::RelationshipCompare;
+use crate::model_traits::ForeignKeyPartialEq;
+use crate::model_traits::HasSchema;
+use crate::model_traits::PrimaryKeyValue;
+use crate::model_traits::UniqueIdentifier;
+use std::marker::PhantomData;
+
+pub struct BelongsToOne<T> {
+    _t: PhantomData<T>,
+    foreign_key: &'static str,
+}
+
+impl<T> PartialEq for BelongsToOne<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.foreign_key == other.foreign_key
+    }
+}
+
+impl<T> Clone for BelongsToOne<T> {
+    fn clone(&self) -> Self {
+        BelongsToOne {
+            _t: Default::default(),
+            foreign_key: self.foreign_key,
+        }
+    }
+}
+
+impl<T> BelongsToOne<T> {
+    pub fn using(fk: &'static str) -> BelongsToOne<T> {
+        BelongsToOne {
+            _t: Default::default(),
+            foreign_key: fk,
+        }
+    }
+}
+
+impl<R: Send> Relationship<R> for BelongsToOne<R> {
+    fn my_key<ME, THEM>(&self) -> String
+    where
+        ME: UniqueIdentifier,
+        THEM: UniqueIdentifier,
+    {
+        THEM::id_column().name().to_owned()
+    }
+    fn their_key<ME, THEM>(&self) -> String
+    where
+        ME: UniqueIdentifier,
+        THEM: UniqueIdentifier,
+    {
+        self.foreign_key.to_owned()
+    }
+}
+
+impl<T, R> RelationshipCompare<T, R> for BelongsToOne<R>
+where
+    Self: Relationship<R>,
+    T: PrimaryKeyValue + HasSchema,
+    T::Schema: UniqueIdentifier,
+    R: HasSchema,
+    R::Schema: UniqueIdentifier,
+    R: ForeignKeyPartialEq<T::PrimaryKeyType>,
+{
+    fn is_related(&self, source: &T, other: &R) -> bool {
+        let pk = source.primary_key_value();
+        let fk_field: String = Self::their_key::<R::Schema, T::Schema>(self);
+        other.eq(&fk_field, &pk)
+    }
+}

--- a/welds/src/relations/hasmany.rs
+++ b/welds/src/relations/hasmany.rs
@@ -1,0 +1,68 @@
+use super::Relationship;
+use super::RelationshipCompare;
+use crate::model_traits::ForeignKeyPartialEq;
+use crate::model_traits::HasSchema;
+use crate::model_traits::PrimaryKeyValue;
+use crate::model_traits::UniqueIdentifier;
+use std::marker::PhantomData;
+
+pub struct HasMany<T> {
+    _t: PhantomData<T>,
+    foreign_key: &'static str,
+}
+
+impl<T> HasMany<T> {
+    pub fn using(fk: &'static str) -> HasMany<T> {
+        HasMany {
+            _t: Default::default(),
+            foreign_key: fk,
+        }
+    }
+}
+
+impl<T> PartialEq for HasMany<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.foreign_key == other.foreign_key
+    }
+}
+impl<T> Clone for HasMany<T> {
+    fn clone(&self) -> Self {
+        Self {
+            _t: Default::default(),
+            foreign_key: self.foreign_key,
+        }
+    }
+}
+
+impl<R: Send> Relationship<R> for HasMany<R> {
+    fn my_key<ME, THEM>(&self) -> String
+    where
+        ME: UniqueIdentifier,
+        THEM: UniqueIdentifier,
+    {
+        THEM::id_column().name().to_owned()
+    }
+    fn their_key<ME, THEM>(&self) -> String
+    where
+        ME: UniqueIdentifier,
+        THEM: UniqueIdentifier,
+    {
+        self.foreign_key.to_owned()
+    }
+}
+
+impl<T, R> RelationshipCompare<T, R> for HasMany<R>
+where
+    Self: Relationship<R>,
+    T: PrimaryKeyValue + HasSchema,
+    T::Schema: UniqueIdentifier,
+    R: HasSchema,
+    R::Schema: UniqueIdentifier,
+    R: ForeignKeyPartialEq<T::PrimaryKeyType>,
+{
+    fn is_related(&self, source: &T, other: &R) -> bool {
+        let pk = source.primary_key_value();
+        let fk_field: String = Self::their_key::<R::Schema, T::Schema>(self);
+        other.eq(&fk_field, &pk)
+    }
+}

--- a/welds/src/relations/hasone.rs
+++ b/welds/src/relations/hasone.rs
@@ -1,0 +1,68 @@
+use super::Relationship;
+use super::RelationshipCompare;
+use crate::model_traits::ForeignKeyPartialEq;
+use crate::model_traits::HasSchema;
+use crate::model_traits::PrimaryKeyValue;
+use crate::model_traits::UniqueIdentifier;
+use std::marker::PhantomData;
+
+pub struct HasOne<T> {
+    _t: PhantomData<T>,
+    foreign_key: &'static str,
+}
+
+impl<T> PartialEq for HasOne<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.foreign_key == other.foreign_key
+    }
+}
+impl<T> Clone for HasOne<T> {
+    fn clone(&self) -> Self {
+        Self {
+            _t: Default::default(),
+            foreign_key: self.foreign_key,
+        }
+    }
+}
+
+impl<T> HasOne<T> {
+    pub fn using(fk: &'static str) -> HasOne<T> {
+        HasOne {
+            _t: Default::default(),
+            foreign_key: fk,
+        }
+    }
+}
+
+impl<R: Send> Relationship<R> for HasOne<R> {
+    fn my_key<ME, THEM>(&self) -> String
+    where
+        ME: UniqueIdentifier,
+        THEM: UniqueIdentifier,
+    {
+        self.foreign_key.to_owned()
+    }
+    fn their_key<ME, THEM>(&self) -> String
+    where
+        ME: UniqueIdentifier,
+        THEM: UniqueIdentifier,
+    {
+        ME::id_column().name().to_owned()
+    }
+}
+
+impl<T, R> RelationshipCompare<T, R> for HasOne<R>
+where
+    Self: Relationship<R>,
+    R: PrimaryKeyValue + HasSchema,
+    R::Schema: UniqueIdentifier,
+    T: HasSchema,
+    T::Schema: UniqueIdentifier,
+    T: ForeignKeyPartialEq<R::PrimaryKeyType>,
+{
+    fn is_related(&self, source: &T, other: &R) -> bool {
+        let pk = other.primary_key_value();
+        let fk_field: String = Self::my_key::<R::Schema, T::Schema>(self);
+        source.eq(&fk_field, &pk)
+    }
+}

--- a/welds/src/relations/mod.rs
+++ b/welds/src/relations/mod.rs
@@ -1,188 +1,19 @@
 use crate::model_traits::UniqueIdentifier;
-use std::marker::PhantomData;
 
-pub struct BelongsTo<T> {
-    _t: PhantomData<T>,
-    foreign_key: &'static str,
-}
+mod belongsto;
+pub use belongsto::BelongsTo;
 
-impl<T> BelongsTo<T> {
-    pub fn using(fk: &'static str) -> BelongsTo<T> {
-        BelongsTo {
-            _t: Default::default(),
-            foreign_key: fk,
-        }
-    }
-}
+mod hasmany;
+pub use hasmany::HasMany;
 
-// writing these by hand to ignore PhantomData
-impl<T> PartialEq for BelongsTo<T> {
-    fn eq(&self, other: &Self) -> bool {
-        self.foreign_key == other.foreign_key
-    }
-}
-impl<T> Clone for BelongsTo<T> {
-    fn clone(&self) -> Self {
-        Self {
-            _t: Default::default(),
-            foreign_key: self.foreign_key,
-        }
-    }
-}
+mod hasone;
+pub use hasone::HasOne;
 
-impl<R: Send> Relationship<R> for BelongsTo<R> {
-    fn my_key<ME, THEM>(&self) -> String
-    where
-        ME: UniqueIdentifier,
-        THEM: UniqueIdentifier,
-    {
-        self.foreign_key.to_owned()
-    }
-    fn their_key<ME, THEM>(&self) -> String
-    where
-        ME: UniqueIdentifier,
-        THEM: UniqueIdentifier,
-    {
-        ME::id_column().name().to_owned()
-    }
-}
+mod belongstoone;
+pub use belongstoone::BelongsToOne;
 
-pub struct HasMany<T> {
-    _t: PhantomData<T>,
-    foreign_key: &'static str,
-}
-
-impl<T> HasMany<T> {
-    pub fn using(fk: &'static str) -> HasMany<T> {
-        HasMany {
-            _t: Default::default(),
-            foreign_key: fk,
-        }
-    }
-}
-
-impl<T> PartialEq for HasMany<T> {
-    fn eq(&self, other: &Self) -> bool {
-        self.foreign_key == other.foreign_key
-    }
-}
-impl<T> Clone for HasMany<T> {
-    fn clone(&self) -> Self {
-        Self {
-            _t: Default::default(),
-            foreign_key: self.foreign_key,
-        }
-    }
-}
-
-impl<R: Send> Relationship<R> for HasMany<R> {
-    fn my_key<ME, THEM>(&self) -> String
-    where
-        ME: UniqueIdentifier,
-        THEM: UniqueIdentifier,
-    {
-        THEM::id_column().name().to_owned()
-    }
-    fn their_key<ME, THEM>(&self) -> String
-    where
-        ME: UniqueIdentifier,
-        THEM: UniqueIdentifier,
-    {
-        self.foreign_key.to_owned()
-    }
-}
-
-pub struct HasOne<T> {
-    _t: PhantomData<T>,
-    foreign_key: &'static str,
-}
-
-impl<T> PartialEq for HasOne<T> {
-    fn eq(&self, other: &Self) -> bool {
-        self.foreign_key == other.foreign_key
-    }
-}
-impl<T> Clone for HasOne<T> {
-    fn clone(&self) -> Self {
-        Self {
-            _t: Default::default(),
-            foreign_key: self.foreign_key,
-        }
-    }
-}
-
-impl<T> HasOne<T> {
-    pub fn using(fk: &'static str) -> HasOne<T> {
-        HasOne {
-            _t: Default::default(),
-            foreign_key: fk,
-        }
-    }
-}
-
-impl<R: Send> Relationship<R> for HasOne<R> {
-    fn my_key<ME, THEM>(&self) -> String
-    where
-        ME: UniqueIdentifier,
-        THEM: UniqueIdentifier,
-    {
-        self.foreign_key.to_owned()
-    }
-    fn their_key<ME, THEM>(&self) -> String
-    where
-        ME: UniqueIdentifier,
-        THEM: UniqueIdentifier,
-    {
-        ME::id_column().name().to_owned()
-    }
-}
-
-pub struct BelongsToOne<T> {
-    _t: PhantomData<T>,
-    foreign_key: &'static str,
-}
-
-impl<T> PartialEq for BelongsToOne<T> {
-    fn eq(&self, other: &Self) -> bool {
-        self.foreign_key == other.foreign_key
-    }
-}
-
-impl<T> Clone for BelongsToOne<T> {
-    fn clone(&self) -> Self {
-        BelongsToOne {
-            _t: Default::default(),
-            foreign_key: self.foreign_key,
-        }
-    }
-}
-
-impl<T> BelongsToOne<T> {
-    pub fn using(fk: &'static str) -> BelongsToOne<T> {
-        BelongsToOne {
-            _t: Default::default(),
-            foreign_key: fk,
-        }
-    }
-}
-
-impl<R: Send> Relationship<R> for BelongsToOne<R> {
-    fn my_key<ME, THEM>(&self) -> String
-    where
-        ME: UniqueIdentifier,
-        THEM: UniqueIdentifier,
-    {
-        THEM::id_column().name().to_owned()
-    }
-    fn their_key<ME, THEM>(&self) -> String
-    where
-        ME: UniqueIdentifier,
-        THEM: UniqueIdentifier,
-    {
-        self.foreign_key.to_owned()
-    }
-}
-
+/// Describes how a relationship should be wired up.
+/// Gives info about what DB columns to use on both Models
 pub trait Relationship<R>: Clone + PartialEq + Send {
     fn their_key<R2, T>(&self) -> String
     where
@@ -195,10 +26,13 @@ pub trait Relationship<R>: Clone + PartialEq + Send {
         R2: UniqueIdentifier;
 }
 
-pub trait RelationValue<R> {
-    type ValueType: PartialEq + 'static;
-
-    fn relation_value(&self) -> Self::ValueType;
+/// Used to check if a relationship holds between two models.
+pub trait RelationshipCompare<T, R>
+where
+    Self: Relationship<R>,
+{
+    // return true if the source object is linked to the other object via a the given relationship
+    fn is_related(&self, source: &T, other: &R) -> bool;
 }
 
 pub trait HasRelations {


### PR DESCRIPTION
If issue where a model points to the same modal via two different FKs

for example making this work
```
#[derive(Debug, Default, WeldsModel)]
#[welds(table = "orders")]
#[welds(BelongsTo(product, Product, "product_id"))]
#[welds(BelongsTo(product2, Product, "product_id2"))]
struct Order {
    #[welds(primary_key)]
    pub id: i32,
    pub product_id: Option<i32>,
    pub product_id2: i32,
}
```