### PR TITLE
Re-export welds_connections::errors::Error as welds::error::ConnError

### DIFF
--- a/welds/src/errors/mod.rs
+++ b/welds/src/errors/mod.rs
@@ -1,6 +1,6 @@
 use crate::model_traits::TableIdent;
 use thiserror::Error;
-use welds_connections::Error as ConnError;
+pub use welds_connections::Error as ConnError;
 
 pub type Result<T> = std::result::Result<T, WeldsError>;
 


### PR DESCRIPTION
Re-exports `welds_connections::errors::Error` as `welds::errors::ConnError` so the `enum`'s definition can be accessed without importing the whole `welds-connections` crate, like:

```rust
use welds::errors::{WeldsError, ConnError};
```

I just ran into a scenario where I need to destructure an error to get at the inner Sqlx `DatabaseError` object, but I have to import `welds-connections` just to access the enum because it's a `WeldsError` wrapping a `welds_connections::errors::Error` wrapping an `sqlx::errors::Error`.

What do you think?