### PR TITLE
Feat: enable use of group by and aggregate functions

### DIFF
--- a/tests/postgres/Cargo.toml
+++ b/tests/postgres/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 
 [dependencies]
 testlib = { path = "../testlib" }
-welds = { path = "../../welds", features = ["postgres", "detect", 'check', "migrations"]  }
+welds = { path = "../../welds", features = ["postgres", "detect", 'check', "migrations", "group-by"]  }
 async-std = { version = "1", features = ["attributes"] }
 sqlx = { version = "0.8", features = [ "runtime-async-std", "tls-rustls", "macros", "uuid", "chrono"] }
 log = "0.4.21"

--- a/tests/postgres/tests/all_tests.rs
+++ b/tests/postgres/tests/all_tests.rs
@@ -13,6 +13,7 @@ use welds::state::{DbState, DbStatus};
 use welds::Syntax;
 
 mod extra_types;
+mod group_by;
 mod migrations;
 
 async fn get_conn() -> PostgresClient {

--- a/tests/postgres/tests/group_by/mod.rs
+++ b/tests/postgres/tests/group_by/mod.rs
@@ -1,0 +1,96 @@
+use super::get_conn;
+use welds::prelude::*;
+use welds::exts::VecRowExt;
+
+#[derive(Debug, Clone, WeldsModel)]
+#[welds(table = "teams")]
+#[welds(HasMany(players, Player, "team_id"))]
+pub struct Team {
+    #[welds(primary_key)]
+    pub id: i32,
+    pub city_id: i32,
+    pub name: String,
+}
+#[derive(Debug, Clone, WeldsModel)]
+#[welds(table = "players")]
+#[welds(BelongsTo(team, Team, "team_id"))]
+pub struct Player {
+    #[welds(primary_key)]
+    pub id: i32,
+    pub team_id: i32,
+    pub name: String,
+}
+
+#[derive(Debug, PartialEq, WeldsModel)]
+pub struct TeamWithPlayerCount {
+    pub team_id: i32,
+    pub team_name: String,
+    pub player_count: i64,
+}
+
+#[derive(Debug, PartialEq, WeldsModel)]
+pub struct TeamWithLatestPlayer {
+    pub team_id: i32,
+    pub player_id: i32,
+}
+
+#[test]
+fn should_join_data_with_group_by_and_count() {
+    async_std::task::block_on(async {
+        let conn = get_conn().await;
+
+        let query = Team::all()
+            .select_as(|t| t.id, "team_id")
+            .select_as(|t| t.name, "team_name")
+            .left_join(|t| t.players,
+                Player::all().select_count(|p| p.id, "player_count")
+            )
+            .group_by(|t| t.id)
+            .order_by_asc(|t| t.id);
+
+        let collection: Vec<TeamWithPlayerCount> = query.run(&conn).await.unwrap().collect_into().unwrap();
+
+        assert_eq!(
+            collection[0],
+            TeamWithPlayerCount { team_id: 1, team_name: "Liverpool FC".to_string(), player_count: 1 }
+        );
+        assert_eq!(
+            collection[1],
+            TeamWithPlayerCount { team_id: 2, team_name: "Manchester City".to_string(), player_count: 1 }
+        );
+        assert_eq!(
+            collection[2],
+            TeamWithPlayerCount { team_id: 3, team_name: "Manchester United".to_string(), player_count: 2 }
+        );
+    })
+}
+
+#[test]
+fn should_join_data_with_group_by_and_max() {
+    async_std::task::block_on(async {
+        let conn = get_conn().await;
+
+        let query = Team::all()
+            .select_as(|t| t.id, "team_id")
+            .left_join(|t| t.players,
+                Player::all().select_max(|p| p.id, "player_id")
+            )
+            .group_by(|t| t.id)
+            .order_by_asc(|t| t.id);
+
+        let collection: Vec<TeamWithLatestPlayer> = query.run(&conn).await.unwrap().collect_into().unwrap();
+
+        assert_eq!(
+            collection[0],
+            TeamWithLatestPlayer { team_id: 1, player_id: 1 }
+        );
+        assert_eq!(
+            collection[1],
+            TeamWithLatestPlayer { team_id: 2, player_id: 2 }
+        );
+        assert_eq!(
+            collection[2],
+            TeamWithLatestPlayer { team_id: 3, player_id: 4 }
+        );
+    })
+}

--- a/tests/sqlite/Cargo.toml
+++ b/tests/sqlite/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 testlib = { path = "../testlib" }
-welds = { path = "../../welds", features = ["sqlite", 'detect', 'check', "migrations"]  }
+welds = { path = "../../welds", features = ["sqlite", 'detect', 'check', "migrations", "group-by"]  }
 async-std = { version = "1", features = ["attributes"] }
 sqlx = { version = "0.8", features = [ "runtime-async-std", "tls-rustls", "macros", "chrono", "uuid"] }
 chrono = "0.4.38"

--- a/tests/sqlite/tests/all_tests.rs
+++ b/tests/sqlite/tests/all_tests.rs
@@ -11,6 +11,7 @@ pub mod bulk_delete;
 pub mod bulk_update;
 pub mod callbacks;
 pub mod extra_types;
+pub mod group_by;
 pub mod includes;
 pub mod migrations;
 pub mod select_col;

--- a/tests/sqlite/tests/group_by/mod.rs
+++ b/tests/sqlite/tests/group_by/mod.rs
@@ -1,0 +1,95 @@
+use crate::get_conn;
+use welds::WeldsModel;
+use welds::exts::VecRowExt;
+
+#[derive(Debug, Clone, WeldsModel)]
+#[welds(table = "Teams")]
+#[welds(HasMany(players, Player, "team_id"))]
+pub struct Team {
+    #[welds(primary_key)]
+    pub id: i32,
+    pub city_id: i32,
+    pub name: String,
+}
+#[derive(Debug, Clone, WeldsModel)]
+#[welds(table = "Players")]
+#[welds(BelongsTo(team, Team, "team_id"))]
+pub struct Player {
+    #[welds(primary_key)]
+    pub id: i32,
+    pub team_id: i32,
+    pub name: String,
+}
+
+#[derive(Debug, PartialEq, WeldsModel)]
+pub struct TeamWithPlayerCount {
+    pub team_id: i32,
+    pub team_name: String,
+    pub player_count: i32,
+}
+
+#[derive(Debug, PartialEq, WeldsModel)]
+pub struct TeamWithLatestPlayer {
+    pub team_id: i32,
+    pub player_id: i32,
+    pub latest_player: String,
+}
+
+#[test]
+fn should_join_data_with_group_by_and_count() {
+    async_std::task::block_on(async {
+        let conn = get_conn().await;
+
+        let query = Team::all()
+            .select_as(|t| t.id, "team_id")
+            .select_as(|t| t.name, "team_name")
+            .left_join(|t| t.players, Player::all().select_count(|p| p.id, "player_count"))
+            .group_by(|t| t.id);
+
+        let collection: Vec<TeamWithPlayerCount> = query.run(&conn).await.unwrap().collect_into().unwrap();
+
+        assert_eq!(
+            collection[0],
+            TeamWithPlayerCount { team_id: 1, team_name: "Liverpool FC".to_string(), player_count: 1 }
+        );
+        assert_eq!(
+            collection[1],
+            TeamWithPlayerCount { team_id: 2, team_name: "Manchester City".to_string(), player_count: 1 }
+        );
+        assert_eq!(
+            collection[2],
+            TeamWithPlayerCount { team_id: 3, team_name: "Manchester United".to_string(), player_count: 2 }
+        );
+    })
+}
+
+#[test]
+fn should_join_data_with_group_by_and_max() {
+    async_std::task::block_on(async {
+        let conn = get_conn().await;
+
+        let query = Team::all()
+            .select_as(|t| t.id, "team_id")
+            .left_join(|t| t.players,
+                Player::all()
+                    .select_max(|p| p.id, "player_id")
+                    .select_as(|p| p.name, "latest_player")
+            )
+            .group_by(|t| t.id);
+
+        let collection: Vec<TeamWithLatestPlayer> = query.run(&conn).await.unwrap().collect_into().unwrap();
+
+        assert_eq!(
+            collection[0],
+            TeamWithLatestPlayer { team_id: 1, player_id: 1, latest_player: "Andy Anderson".to_string() }
+        );
+        assert_eq!(
+            collection[1],
+            TeamWithLatestPlayer { team_id: 2, player_id: 2, latest_player: "Bobby Biggs".to_string() }
+        );
+        assert_eq!(
+            collection[2],
+            TeamWithLatestPlayer { team_id: 3, player_id: 4, latest_player: "Danny Dier".to_string() }
+        );
+    })
+}

--- a/tests/sqlite/tests/select_col/mod.rs
+++ b/tests/sqlite/tests/select_col/mod.rs
@@ -130,3 +130,15 @@ fn should_be_able_to_select_out_columns_of_the_name_name() {
         let _rows = rows.unwrap();
     })
 }
+
+#[test]
+fn should_be_able_to_select_all_columns() {
+    async_std::task::block_on(async {
+        let query = Order2::all().select_all();
+
+        assert_eq!(
+            query.to_sql(Syntax::Sqlite),
+            "SELECT t1.* FROM orders t1"
+        );
+    });
+}

--- a/tests/testlib/databases/postgres/01_create_tables.sql
+++ b/tests/testlib/databases/postgres/01_create_tables.sql
@@ -73,4 +73,14 @@ CREATE TABLE extra_types (
     datetimetz_col TIMESTAMPTZ NOT NULL
 );
 
+CREATE TABLE teams (
+    id serial PRIMARY KEY,
+    city_id INTEGER NOT NULL,
+    name text
+);
 
+CREATE TABLE players (
+    id serial PRIMARY KEY,
+    team_id INTEGER NOT NULL,
+    name text
+);

--- a/tests/testlib/databases/postgres/02_add_test_data.sql
+++ b/tests/testlib/databases/postgres/02_add_test_data.sql
@@ -92,8 +92,18 @@ INSERT INTO Orders (
 , 1000000.09
 );
 
+INSERT INTO teams (id, city_id, name) VALUES
+(1, 2, 'Liverpool FC'),
+(2, 3, 'Manchester City'),
+(3, 3, 'Manchester United');
+
+INSERT INTO players (id, team_id, name) VALUES
+(1, 1, 'Andy Anderson'),
+(2, 2, 'Bobby Biggs'),
+(3, 3, 'Chris Christoferson'),
+(4, 3, 'Danny Dier');
+
 
 -- RESET THE NEXT IDs
 SELECT setval('products_product_id_seq', COALESCE((SELECT MAX(product_id)+1 FROM products), 1), false);
 SELECT setval('orders_id_seq', COALESCE((SELECT MAX(id)+1 FROM orders), 1), false);
-

--- a/welds/Cargo.toml
+++ b/welds/Cargo.toml
@@ -30,6 +30,7 @@ welds-macros = { path="../welds-macros", version = "^0.4.14" }
 "mock" = []
 "check" = ["detect", "colored"]
 "migrations" = ["detect"]
+"group-by" = []
 "tracing" = ["welds-connections/tracing"]
 
 

--- a/welds/README.md
+++ b/welds/README.md
@@ -102,6 +102,7 @@ welds-connections features needed for mssql (tiberius):
  - [Fetch related objects with include](https://github.com/weldsorm/welds/blob/main/welds/examples/includes.rs)
  - [Hooks, Callback when models (Save/Update/Delete)](https://github.com/weldsorm/welds/blob/main/welds/examples/hooks.rs)
  - [Scopes for your Models](https://github.com/weldsorm/welds/blob/main/welds/examples/scopes.rs)
+ - [Grouping and Aggregate Functions](https://github.com/weldsorm/welds/blob/main/welds/examples/aggregating.rs)
  - [Migrations](https://github.com/weldsorm/welds/blob/main/welds/examples/migrations.rs)
  - [Wrapping operations in Transactions](https://github.com/weldsorm/welds/blob/main/welds/examples/transactions.rs)
  - [Checking DB schema matches compiled structs](https://github.com/weldsorm/welds/blob/main/welds/examples/verify_tables.rs)

--- a/welds/examples/aggregating.rs
+++ b/welds/examples/aggregating.rs
@@ -1,0 +1,64 @@
+use welds::prelude::*;
+
+// Enabling the `group-by` feature exposes some additional querying methods such as
+// `group_by()`, `select_count()` and `select_max()` for grouping and aggregating.
+// Using these functions can result in queries which compile correctly but return
+// errors at runtime (if the syntax is wrong), so use them with care.
+
+// Team model, with HasMany association to Player
+#[derive(Debug, Clone, WeldsModel)]
+#[welds(table = "Teams")]
+#[welds(HasMany(players, Player, "team_id"))]
+pub struct Team {
+    #[welds(primary_key)]
+    pub id: i32,
+    pub name: String,
+}
+
+// Player model, with BelongsTo association for Team
+#[derive(Debug, WeldsModel)]
+#[welds(table = "Players")]
+#[welds(BelongsTo(team, Team, "team_id"))]
+pub struct Player {
+    #[welds(primary_key)]
+    pub id: i32,
+    pub team_id: i32,
+    pub name: String,
+}
+
+// Struct for collecting results for Team query with a count of it's associated Player(s)
+#[derive(Debug, WeldsModel)]
+pub struct TeamWithPlayerCount {
+    pub id: i32,
+    pub name: String,
+    pub player_count: i32
+}
+
+#[async_std::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let connection_string = "sqlite::memory:";
+    let client = welds::connections::connect(connection_string).await?;
+
+    // Build an in memory DB with a schema
+    let schema = include_str!("../../tests/testlib/databases/sqlite/01_create_tables.sql");
+    client.execute(schema, &[]).await?;
+
+    // Populate the DB some example data
+    let data = include_str!("../../tests/testlib/databases/sqlite/02_add_test_data.sql");
+    client.execute(data).await?;
+
+    // Example query; select all columns from teams table where team name starts with "L",
+    // left join to the players table, select COUNT(players.id) as "player_count",
+    // group by team id and order by team name:
+    let query = Team::where_col(|team| team.name.like("L%"))
+        .select_all()
+        .left_join(|team| team.players, Player::all().select_count(|player| player.id, "player_count"))
+        .group_by(|team| team.id)
+        .order_by_asc(|team| team.name);
+
+    // Collect the resulting rows into a Vec of TeamWithPlayerCount structs containing
+    // each team's id, name, and player_count
+    let collection: Vec<TeamWithPlayerCount> = query.run(&client).await?.collection_into()?;
+
+    Ok(())
+}

--- a/welds/src/lib.rs
+++ b/welds/src/lib.rs
@@ -144,6 +144,7 @@
 //! - migrations - adds all the migration structs and traits
 //! - full - all the features excluding (mock)
 //! - mock - Use for testing ONLY. Enables mocking out database schemas
+//! - group-by - Enables use of group_by and aggregate functions
 //!
 //!
 //! # Important Notes:

--- a/welds/src/query/builder/mod.rs
+++ b/welds/src/query/builder/mod.rs
@@ -343,8 +343,7 @@ where
         self,
         lam: impl Fn(<T as HasSchema>::Schema) -> FN,
     ) -> SelectBuilder<T> {
-        let sb = SelectBuilder::new(self);
-        sb.select(lam)
+        SelectBuilder::new(self).select(lam)
     }
 
     /// Select only the specific columns
@@ -355,14 +354,12 @@ where
         lam: impl Fn(<T as HasSchema>::Schema) -> FN,
         as_name: &'static str,
     ) -> SelectBuilder<T> {
-        let sb = SelectBuilder::new(self);
-        sb.select_as(lam, as_name)
+        SelectBuilder::new(self).select_as(lam, as_name)
     }
 
     /// Select all columns, equivalent to `SELECT table_name.*`
     pub fn select_all(self) -> SelectBuilder<T> {
-        let sb = SelectBuilder::new(self);
-        sb.select_all()
+        SelectBuilder::new(self).select_all()
     }
 
     pub fn select_count<V, FN: AsFieldName<V>>(
@@ -370,8 +367,7 @@ where
         lam: impl Fn(<T as HasSchema>::Schema) -> FN,
         as_name: &'static str,
     ) -> SelectBuilder<T> {
-        let sb = SelectBuilder::new(self);
-        sb.select_count(lam, as_name)
+        SelectBuilder::new(self).select_count(lam, as_name)
     }
 
     pub fn select_max<V, FN: AsFieldName<V>>(
@@ -379,8 +375,7 @@ where
         lam: impl Fn(<T as HasSchema>::Schema) -> FN,
         as_name: &'static str,
     ) -> SelectBuilder<T> {
-        let sb = SelectBuilder::new(self);
-        sb.select_max(lam, as_name)
+        SelectBuilder::new(self).select_max(lam, as_name)
     }
 
     pub fn select_min<V, FN: AsFieldName<V>>(
@@ -388,8 +383,7 @@ where
         lam: impl Fn(<T as HasSchema>::Schema) -> FN,
         as_name: &'static str,
     ) -> SelectBuilder<T> {
-        let sb = SelectBuilder::new(self);
-        sb.select_min(lam, as_name)
+        SelectBuilder::new(self).select_min(lam, as_name)
     }
 
     /// Changes this query Into a sql UPDATE.
@@ -422,8 +416,7 @@ where
         FIELD: AsFieldName<V>,
         V: 'static + Sync + Send + Clone + Param,
     {
-        let ub = UpdateBuilder::new(self);
-        ub.set(lam, value)
+        UpdateBuilder::new(self).set(lam, value)
     }
 
     /// Changes this query Into a sql UPDATE.
@@ -454,8 +447,7 @@ where
     where
         <T as HasSchema>::Schema: Default,
     {
-        let ub = UpdateBuilder::new(self);
-        ub.set_col(lam)
+        UpdateBuilder::new(self).set_col(lam)
     }
 
     /// Nulls out the value from the lambda in the database
@@ -468,8 +460,7 @@ where
         FIELD: AsFieldName<V> + AsOptField,
         V: 'static + Sync + Send + Clone + Param,
     {
-        let ub = UpdateBuilder::new(self);
-        ub.set_null(lam)
+        UpdateBuilder::new(self).set_null(lam)
     }
 
     /// Write custom sql for the right side of a SET clause
@@ -506,8 +497,7 @@ where
         FIELD: AsFieldName<V>,
         V: 'static + Sync + Send + Clone + Param,
     {
-        let ub = UpdateBuilder::new(self);
-        ub.set_manual(lam, sql, params)
+        UpdateBuilder::new(self).set_manual(lam, sql, params)
     }
 
     /// Include an other related to this one. `BelongsTo` `HasMany`.
@@ -529,7 +519,6 @@ where
         R: TryFrom<crate::connections::Row>,
         crate::errors::WeldsError: From<<R as TryFrom<crate::connections::Row>>::Error>,
     {
-        let ib = IncludeBuilder::new(self);
-        ib.include(relationship)
+        IncludeBuilder::new(self).include(relationship)
     }
 }

--- a/welds/src/query/builder/mod.rs
+++ b/welds/src/query/builder/mod.rs
@@ -359,6 +359,33 @@ where
         sb.select_as(lam, as_name)
     }
 
+    pub fn select_count<V, FN: AsFieldName<V>>(
+        self,
+        lam: impl Fn(<T as HasSchema>::Schema) -> FN,
+        as_name: &'static str,
+    ) -> SelectBuilder<T> {
+        let sb = SelectBuilder::new(self);
+        sb.select_count(lam, as_name)
+    }
+
+    pub fn select_max<V, FN: AsFieldName<V>>(
+        self,
+        lam: impl Fn(<T as HasSchema>::Schema) -> FN,
+        as_name: &'static str,
+    ) -> SelectBuilder<T> {
+        let sb = SelectBuilder::new(self);
+        sb.select_max(lam, as_name)
+    }
+
+    pub fn select_min<V, FN: AsFieldName<V>>(
+        self,
+        lam: impl Fn(<T as HasSchema>::Schema) -> FN,
+        as_name: &'static str,
+    ) -> SelectBuilder<T> {
+        let sb = SelectBuilder::new(self);
+        sb.select_min(lam, as_name)
+    }
+
     /// Changes this query Into a sql UPDATE.
     /// Sets the value from the lambda in the database
     ///

--- a/welds/src/query/builder/mod.rs
+++ b/welds/src/query/builder/mod.rs
@@ -359,6 +359,12 @@ where
         sb.select_as(lam, as_name)
     }
 
+    /// Select all columns, equivalent to `SELECT table_name.*`
+    pub fn select_all(self) -> SelectBuilder<T> {
+        let sb = SelectBuilder::new(self);
+        sb.select_all()
+    }
+
     pub fn select_count<V, FN: AsFieldName<V>>(
         self,
         lam: impl Fn(<T as HasSchema>::Schema) -> FN,

--- a/welds/src/query/builder/mod.rs
+++ b/welds/src/query/builder/mod.rs
@@ -362,6 +362,7 @@ where
         SelectBuilder::new(self).select_all()
     }
 
+    #[cfg(feature = "group-by")]
     pub fn select_count<V, FN: AsFieldName<V>>(
         self,
         lam: impl Fn(<T as HasSchema>::Schema) -> FN,
@@ -370,6 +371,7 @@ where
         SelectBuilder::new(self).select_count(lam, as_name)
     }
 
+    #[cfg(feature = "group-by")]
     pub fn select_max<V, FN: AsFieldName<V>>(
         self,
         lam: impl Fn(<T as HasSchema>::Schema) -> FN,
@@ -378,6 +380,7 @@ where
         SelectBuilder::new(self).select_max(lam, as_name)
     }
 
+    #[cfg(feature = "group-by")]
     pub fn select_min<V, FN: AsFieldName<V>>(
         self,
         lam: impl Fn(<T as HasSchema>::Schema) -> FN,

--- a/welds/src/query/select_cols/exec.rs
+++ b/welds/src/query/select_cols/exec.rs
@@ -101,6 +101,9 @@ where
                     cols.push(col);
                 }
             }
+            SelectKind::All => {
+                cols.push(format!("{}.*", alias));
+            }
             SelectKind::Count => {
                 let col = format!("COUNT({}.{}) AS {}", alias, colname, fieldname);
                 cols.push(col);

--- a/welds/src/query/select_cols/group_by.rs
+++ b/welds/src/query/select_cols/group_by.rs
@@ -1,0 +1,3 @@
+pub(crate) struct GroupBy {
+    pub(crate) col_name: String,
+}

--- a/welds/src/query/select_cols/join.rs
+++ b/welds/src/query/select_cols/join.rs
@@ -64,6 +64,9 @@ impl JoinBuilder {
                         list.push(col);
                     }
                 }
+                SelectKind::All => {
+                    list.push(format!("{}.*", alias));
+                }
                 SelectKind::Count => {
                     let col = format!("COUNT({}.{}) AS {}", alias, colname, fieldname);
                     list.push(col);

--- a/welds/src/query/select_cols/mod.rs
+++ b/welds/src/query/select_cols/mod.rs
@@ -59,6 +59,16 @@ where
         self
     }
 
+    /// Select all columns, equivalent to `SELECT table_name.*`
+    pub fn select_all(mut self) -> SelectBuilder<T> {
+        self.selects.push(SelectColumn {
+            col_name: Default::default(),
+            field_name: Default::default(),
+            kind: SelectKind::All,
+        });
+        self
+    }
+
     /// Add a columns to the specific list of columns that will be selected
     /// uses a sql "AS" to rename the returns column so it can match
     /// the struct you are selecting into

--- a/welds/src/query/select_cols/mod.rs
+++ b/welds/src/query/select_cols/mod.rs
@@ -86,6 +86,7 @@ where
         self
     }
 
+    #[cfg(feature = "group-by")]
     pub fn select_count<V, FN: AsFieldName<V>>(
         mut self,
         lam: impl Fn(<T as HasSchema>::Schema) -> FN,
@@ -100,6 +101,7 @@ where
         self
     }
 
+    #[cfg(feature = "group-by")]
     pub fn select_max<V, FN: AsFieldName<V>>(
         mut self,
         lam: impl Fn(<T as HasSchema>::Schema) -> FN,
@@ -114,6 +116,7 @@ where
         self
     }
 
+    #[cfg(feature = "group-by")]
     pub fn select_min<V, FN: AsFieldName<V>>(
         mut self,
         lam: impl Fn(<T as HasSchema>::Schema) -> FN,
@@ -222,6 +225,7 @@ where
         self
     }
 
+    #[cfg(feature = "group-by")]
     pub fn group_by<V, FN: AsFieldName<V>>(
         mut self,
         lam: impl Fn(<T as HasSchema>::Schema) -> FN,

--- a/welds/src/query/select_cols/select_column.rs
+++ b/welds/src/query/select_cols/select_column.rs
@@ -9,10 +9,13 @@ pub(crate) struct SelectColumn {
 
 pub(crate) enum SelectKind {
     Column,
-    Count,
-    Max,
-    Min,
     All,
+    #[cfg(feature = "group-by")]
+    Count,
+    #[cfg(feature = "group-by")]
+    Max,
+    #[cfg(feature = "group-by")]
+    Min,
 }
 
 impl SelectColumn {
@@ -32,12 +35,15 @@ impl SelectColumn {
             SelectKind::All => {
                 format!("{}.*", alias)
             }
+            #[cfg(feature = "group-by")]
             SelectKind::Count => {
                 format!("COUNT({}.{}) AS {}", alias, colname, fieldname)
             }
+            #[cfg(feature = "group-by")]
             SelectKind::Max => {
                 format!("MAX({}.{}) AS {}", alias, colname, fieldname)
             }
+            #[cfg(feature = "group-by")]
             SelectKind::Min => {
                 format!("MIN({}.{}) AS {}", alias, colname, fieldname)
             }

--- a/welds/src/query/select_cols/select_column.rs
+++ b/welds/src/query/select_cols/select_column.rs
@@ -1,4 +1,12 @@
 pub(crate) struct SelectColumn {
     pub(crate) col_name: String,
     pub(crate) field_name: String,
+    pub(crate) kind: SelectKind,
+}
+
+pub(crate) enum SelectKind {
+    Column,
+    Count,
+    Max,
+    Min
 }

--- a/welds/src/query/select_cols/select_column.rs
+++ b/welds/src/query/select_cols/select_column.rs
@@ -8,5 +8,6 @@ pub(crate) enum SelectKind {
     Column,
     Count,
     Max,
-    Min
+    Min,
+    All,
 }

--- a/welds/src/query/select_cols/select_column.rs
+++ b/welds/src/query/select_cols/select_column.rs
@@ -1,3 +1,6 @@
+use welds_connections::Syntax;
+use crate::writers::ColumnWriter;
+
 pub(crate) struct SelectColumn {
     pub(crate) col_name: String,
     pub(crate) field_name: String,
@@ -10,4 +13,34 @@ pub(crate) enum SelectKind {
     Max,
     Min,
     All,
+}
+
+impl SelectColumn {
+    pub(crate) fn write(&self, syntax: Syntax, alias: &str) -> String {
+        let writer = ColumnWriter::new(syntax);
+        let colname = writer.excape(&self.col_name);
+        let fieldname = writer.excape(&self.field_name);
+
+        match self.kind {
+            SelectKind::Column => {
+                if colname == fieldname {
+                    format!("{}.{}", alias, colname)
+                } else {
+                    format!("{}.{} AS {}", alias, colname, fieldname)
+                }
+            }
+            SelectKind::All => {
+                format!("{}.*", alias)
+            }
+            SelectKind::Count => {
+                format!("COUNT({}.{}) AS {}", alias, colname, fieldname)
+            }
+            SelectKind::Max => {
+                format!("MAX({}.{}) AS {}", alias, colname, fieldname)
+            }
+            SelectKind::Min => {
+                format!("MIN({}.{}) AS {}", alias, colname, fieldname)
+            }
+        }
+    }
 }


### PR DESCRIPTION
- Adds a `select_all` method for selecting all columns from a table.
- Adds `group_by`, `select_count`, `select_max` and `select_min` (behind a feature flag) for grouping and aggregating in queries: https://github.com/weldsorm/welds/issues/89