### PR TITLE
Clean up compiler warnings

### DIFF
--- a/welds-connections/src/row/mod.rs
+++ b/welds-connections/src/row/mod.rs
@@ -73,6 +73,7 @@ impl From<MySqlRow> for Row {
 }
 
 #[cfg(feature = "sqlite")]
+#[allow(unreachable_patterns)]
 impl Row {
     pub fn as_sqlite_row(self) -> Option<SqliteRow> {
         match self.inner {
@@ -83,6 +84,7 @@ impl Row {
 }
 
 #[cfg(feature = "postgres")]
+#[allow(unreachable_patterns)]
 impl Row {
     pub fn as_postgres_row(self) -> Option<PgRow> {
         match self.inner {
@@ -93,6 +95,7 @@ impl Row {
 }
 
 #[cfg(feature = "mysql")]
+#[allow(unreachable_patterns)]
 impl Row {
     pub fn as_mysql_row(self) -> Option<MySqlRow> {
         match self.inner {
@@ -103,6 +106,7 @@ impl Row {
 }
 
 #[cfg(feature = "mssql")]
+#[allow(unreachable_patterns)]
 impl Row {
     pub fn as_mssql_row(self) -> Option<MssqlRowWrapper> {
         match self.inner {

--- a/welds-connections/src/trace.rs
+++ b/welds-connections/src/trace.rs
@@ -1,4 +1,3 @@
-use crate::errors;
 #[cfg(feature = "tracing")]
 use tracing;
 

--- a/welds/src/query/clause/numeric.rs
+++ b/welds/src/query/clause/numeric.rs
@@ -1,6 +1,8 @@
-use super::{AsFieldName, ClauseColVal, ClauseColValEqual, ClauseColValIn, ClauseColValList};
+use super::{AsFieldName, ClauseColVal, ClauseColValEqual, ClauseColValIn};
 use std::marker::PhantomData;
 use welds_connections::Param;
+#[cfg(feature = "postgres")]
+use super::ClauseColValList;
 
 /// Clauses for numeric types such as int, float, etc
 pub struct Numeric<T> {

--- a/welds/src/query/clause/numericopt.rs
+++ b/welds/src/query/clause/numericopt.rs
@@ -1,10 +1,12 @@
 use super::{
-    AsFieldName, AsOptField, ClauseColVal, ClauseColValEqual, ClauseColValIn, ClauseColValList,
+    AsFieldName, AsOptField, ClauseColVal, ClauseColValEqual, ClauseColValIn,
 };
 use crate::query::optional::HasSomeNone;
 use crate::query::optional::Optional;
 use std::marker::PhantomData;
 use welds_connections::Param;
+#[cfg(feature = "postgres")]
+use super::ClauseColValList;
 
 pub struct NumericOpt<T> {
     col: String,

--- a/welds/src/writers/types.rs
+++ b/welds/src/writers/types.rs
@@ -288,6 +288,7 @@ const POSTGRES_PAIRS: &[Pair] = &[
 ];
 
 /// Returns true if two types are a match
+#[allow(dead_code)]
 pub(crate) fn are_equivalent_types(pairs: &[Pair], db: &str, rust: &str) -> bool {
     let db = db.trim().to_uppercase();
     for pair in pairs {
@@ -300,6 +301,7 @@ pub(crate) fn are_equivalent_types(pairs: &[Pair], db: &str, rust: &str) -> bool
 
 /// Override the type of a column to the type that should be used
 /// to crate its PK value. e.g.
+#[allow(dead_code)]
 pub(crate) fn pk_override(syntax: Syntax, db_type: &str) -> Option<&'static str> {
     // Use the Serial type to create the PKs, the type will be reported back as int..
     if let Syntax::Postgres = syntax {


### PR DESCRIPTION
Compiling an app with welds currently emits several warnings during compilation:
```rust
Compiling welds v0.4.14
warning: `welds-connections` (lib) generated 2 warnings (run `cargo fix --lib -p welds-connections` to apply 1 suggestion)
warning: unused import: `ClauseColValList`
 --> .../welds/welds/src/query/clause/numeric.rs:1:75
  |
1 | use super::{AsFieldName, ClauseColVal, ClauseColValEqual, ClauseColValIn, ClauseColValList};
  |                                                                           ^^^^^^^^^^^^^^^^
  |
  = note: `#[warn(unused_imports)]` on by default

warning: unused import: `ClauseColValList`
 --> .../welds/welds/src/query/clause/numericopt.rs:2:79
  |
2 |     AsFieldName, AsOptField, ClauseColVal, ClauseColValEqual, ClauseColValIn, ClauseColValList,
  |                                                                               ^^^^^^^^^^^^^^^^

warning: function `are_equivalent_types` is never used
   --> .../welds/welds/src/writers/types.rs:291:15
    |
291 | pub(crate) fn are_equivalent_types(pairs: &[Pair], db: &str, rust: &str) -> bool {
    |               ^^^^^^^^^^^^^^^^^^^^
    |
    = note: `#[warn(dead_code)]` on by default

warning: function `pk_override` is never used
   --> .../welds/welds/src/writers/types.rs:303:15
    |
303 | pub(crate) fn pk_override(syntax: Syntax, db_type: &str) -> Option<&'static str> {
    |  
```
Most of these warnings relate to things that could _potentially_ be used, depending on which combination of feature flags are enabled, some are methods which are used by `welds-connections` or are used in tests (but might not be used by a downstream consumer).

Fixes all outstanding compiler warnings.