### PR TITLE
Run tests in Github Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,37 @@
+name: Welds CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        test_path:
+          - ./tests
+          - ./tests/mssql
+          - ./tests/mysql
+          - ./tests/postgres
+          - ./tests/sqlite
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-
+      - name: Run tests ${{ matrix.test_path }}
+        working-directory: ${{ matrix.test_path }}
+        run: cargo test


### PR DESCRIPTION
Adds a basic workflow to run the test suite in a Github Action on all PRs or pushes to `main`, broken down into 5 actions for the generic tests, plus the specific tests for each database type (mssql, mysql, postgres, sqlite).

![Screenshot from 2025-03-29 15-34-22](https://github.com/user-attachments/assets/bce573b3-b1a0-4393-a06d-064ea89159e2)
