### PR TITLE
Group By: return error if group by clause is missing

### DIFF
--- a/tests/sqlite/tests/group_by/mod.rs
+++ b/tests/sqlite/tests/group_by/mod.rs
@@ -1,5 +1,5 @@
 use crate::get_conn;
-use welds::WeldsModel;
+use welds::{WeldsError, WeldsModel};
 use welds::exts::VecRowExt;
 
 #[derive(Debug, Clone, WeldsModel)]
@@ -91,5 +91,23 @@ fn should_join_data_with_group_by_and_max() {
             collection[2],
             TeamWithLatestPlayer { team_id: 3, player_id: 4, latest_player: "Danny Dier".to_string() }
         );
+    })
+}
+
+#[test]
+fn should_return_an_error_if_group_by_clause_is_missing() {
+    async_std::task::block_on(async {
+        let conn = get_conn().await;
+
+        let result = Team::all()
+            .select_max(|t| t.id, "max_id")
+            .run(&conn).await;
+
+        match result {
+            Ok(_) => panic!(),
+            Err(e) => {
+                assert_eq!(e.to_string(), WeldsError::ColumnMissingFromGroupBy.to_string())
+            }
+        }
     })
 }

--- a/welds/src/errors/mod.rs
+++ b/welds/src/errors/mod.rs
@@ -6,6 +6,8 @@ pub type Result<T> = std::result::Result<T, WeldsError>;
 
 #[derive(Error, Debug)]
 pub enum WeldsError {
+    #[error("A group by clause is required for this query")]
+    ColumnMissingFromGroupBy,
     #[error("An Error From the Database: {0}")]
     Database(ConnError),
     #[error("Could not find tablebase table {0}")]

--- a/welds/src/query/select_cols/select_column.rs
+++ b/welds/src/query/select_cols/select_column.rs
@@ -7,6 +7,13 @@ pub(crate) struct SelectColumn {
     pub(crate) kind: SelectKind,
 }
 
+impl SelectColumn {
+    pub fn is_aggregate(&self) -> bool {
+        ![SelectKind::All, SelectKind::Column].contains(&self.kind)
+    }
+}
+
+#[derive(PartialEq)]
 pub(crate) enum SelectKind {
     Column,
     All,


### PR DESCRIPTION
Returns an error when calling `run()` on `SelectBuilder` when there are aggregate functions used in selects but no group by clause has been defined.