### PR TITLE
Group By: Emit a trace event on error

### DIFF
--- a/welds-connections/src/trace.rs
+++ b/welds-connections/src/trace.rs
@@ -3,7 +3,7 @@ use tracing;
 
 /// Emits an event when an error is returned from the client, if the "tracing" feature
 /// is enabled and a corresponding tracing-subscriber is registered, otherwise no-op
-pub(crate) fn db_error<T, E>(result: Result<T, E>) -> Result<T, E>
+pub fn db_error<T, E>(result: Result<T, E>) -> Result<T, E>
 where
     E: std::fmt::Display,
 {

--- a/welds/src/query/select_cols/exec.rs
+++ b/welds/src/query/select_cols/exec.rs
@@ -1,3 +1,4 @@
+use welds_connections::trace;
 use crate::errors::Result;
 use crate::model_traits::{HasSchema, TableColumns, TableInfo};
 use crate::query::clause::ParamArgs;
@@ -64,7 +65,7 @@ where
     where
         <T as HasSchema>::Schema: TableInfo + TableColumns,
     {
-        self.validate_group_by()?;
+        trace::db_error(self.validate_group_by())?;
         let syntax = client.syntax();
         let mut args: Option<ParamArgs> = Some(Vec::default());
         let sql = self.sql_internal(syntax, &mut args);


### PR DESCRIPTION
I was thinking of adding a page to the welds book on tracing options and realised this error won't currently emit a trace event, which is inconsistent.