### PR TITLE
Allow manual ordering on joined tables and/or aliased columns

### DIFF
--- a/welds/src/query/builder/mod.rs
+++ b/welds/src/query/builder/mod.rs
@@ -333,8 +333,9 @@ where
     }
 
     /// Manually write the order by part of the query
-    pub fn order_manual(mut self, sql: &str) -> Self {
-        self.orderby.push(OrderBy::new(sql.to_string(), ""));
+    /// NOTE: use '$' for table prefix/alias. It will be swapped out for the prefix used at runtime
+    pub fn order_manual(mut self, sql: &'static str) -> Self {
+        self.orderby.push(OrderBy::new_manual(sql.to_string(), ""));
         self
     }
 

--- a/welds/src/query/select_cols/mod.rs
+++ b/welds/src/query/select_cols/mod.rs
@@ -275,6 +275,13 @@ where
         self
     }
 
+    /// Manually write the order by part of the query.
+    /// NOTE: use '$' for table prefix/alias. It will be swapped out for the prefix used at runtime
+    pub fn order_manual(mut self, sql: &'static str) -> Self {
+        self.qb = self.qb.order_manual(sql);
+        self
+    }
+
     pub(crate) fn set_aliases(&mut self, alias_asigner: &Arc<TableAlias>) {
         self.qb.set_aliases(alias_asigner);
         for join in &mut self.joins {


### PR DESCRIPTION
~~I ran into some cases where `order_manual()` isn't quite enough flexibility, as it automatically assigns the table alias.~~
~~What do you think to `order_by_raw()`?~~

Updated purpose/scope; changes to `order_manual()`:
- `order_manual()` now uses `&'static` for it's sql argument
- `order_manual()` no longer inserts the table alias by default
- `order_manual()` now interpolates `$` as the table alias, like similar functions (`set_manual()`, etc)
- `order_manual()` is also added to the `SelectBuilder` interface (previously was only available in `QueryBuilder`)
- test added for `order_manual()` output, with three different syntax examples