### PR TITLE
Drop unused dependencies

### DIFF
--- a/welds-connections/Cargo.toml
+++ b/welds-connections/Cargo.toml
@@ -37,7 +37,6 @@ futures = {version= "0.3", optional=true }
 futures-util = { version= "0.3", optional=true }
 log = "0.4"
 sqlx = { version = "0.8", features = [], optional = true }
-thiserror = "1.0.57"
 tracing = { version = "0.1", optional = true }
 tokio = { version = "1", features = [], optional = true }
 tokio-util = { version = "0.7", features = ["full"], optional = true }

--- a/welds-macros/Cargo.toml
+++ b/welds-macros/Cargo.toml
@@ -15,7 +15,6 @@ proc-macro = true
 
 [dependencies]
 syn = { version = "^1.0", features = ["extra-traits"] }
-log = "^0.4"
 quote = "^1.0"
 proc-macro2 = "1"
 

--- a/welds/Cargo.toml
+++ b/welds/Cargo.toml
@@ -13,7 +13,6 @@ description = "An async ORM for (postgres, mssql, mysql, sqlite)"
 [dependencies]
 welds-connections = { path="../welds-connections", version = "^0.4.15" }
 async-trait = "0.1"
-log = "0.4"
 colored = { version="2", optional = true }
 anyhow = "1.0"
 thiserror = "1.0"


### PR DESCRIPTION
Seems like these deps are no longer used anywhere in their respective crates..?