### PR TITLE
feat: adding `SUM()` and `AVG()` aggregate functions

### DIFF
--- a/tests/sqlite/tests/select_col/mod.rs
+++ b/tests/sqlite/tests/select_col/mod.rs
@@ -165,6 +165,42 @@ fn should_be_able_to_select_column_max() {
 }
 
 #[test]
+fn should_be_able_to_select_column_min() {
+    async_std::task::block_on(async {
+        let query = Order2::all().select_min(|o| o.oid, "oid_min");
+
+        assert_eq!(
+            query.to_sql(Syntax::Sqlite),
+            "SELECT MIN(t1.\"oid\") AS \"oid_min\" FROM orders t1"
+        );
+    });
+}
+
+#[test]
+fn should_be_able_to_select_column_avg() {
+    async_std::task::block_on(async {
+        let query = Order2::all().select_avg(|o| o.oid, "oid_avg");
+
+        assert_eq!(
+            query.to_sql(Syntax::Sqlite),
+            "SELECT AVG(t1.\"oid\") AS \"oid_avg\" FROM orders t1"
+        );
+    });
+}
+
+#[test]
+fn should_be_able_to_select_column_sum() {
+    async_std::task::block_on(async {
+        let query = Order2::all().select_sum(|o| o.oid, "oid_sum");
+
+        assert_eq!(
+            query.to_sql(Syntax::Sqlite),
+            "SELECT SUM(t1.\"oid\") AS \"oid_sum\" FROM orders t1"
+        );
+    });
+}
+
+#[test]
 fn should_be_able_to_join_and_group_by() {
     async_std::task::block_on(async {
         let query = Order2::all()

--- a/welds/src/query/builder/mod.rs
+++ b/welds/src/query/builder/mod.rs
@@ -395,6 +395,22 @@ where
         SelectBuilder::new(self).select_min(lam, as_name)
     }
 
+    pub fn select_avg<V, FN: AsFieldName<V>>(
+        self,
+        lam: impl Fn(<T as HasSchema>::Schema) -> FN,
+        as_name: &'static str,
+    ) -> SelectBuilder<T> {
+        SelectBuilder::new(self).select_avg(lam, as_name)
+    }
+
+    pub fn select_sum<V, FN: AsFieldName<V>>(
+        self,
+        lam: impl Fn(<T as HasSchema>::Schema) -> FN,
+        as_name: &'static str,
+    ) -> SelectBuilder<T> {
+        SelectBuilder::new(self).select_sum(lam, as_name)
+    }
+
     /// Changes this query Into a sql UPDATE.
     /// Sets the value from the lambda in the database
     ///

--- a/welds/src/query/select_cols/mod.rs
+++ b/welds/src/query/select_cols/mod.rs
@@ -140,6 +140,34 @@ where
         self
     }
 
+    pub fn select_avg<V, FN: AsFieldName<V>>(
+        mut self,
+        lam: impl Fn(<T as HasSchema>::Schema) -> FN,
+        as_name: &'static str,
+    ) -> SelectBuilder<T> {
+        let field = lam(Default::default());
+        self.selects.push(SelectColumn {
+            col_name: field.colname().to_string(),
+            field_name: as_name.to_string(),
+            kind: SelectKind::Average,
+        });
+        self
+    }
+
+    pub fn select_sum<V, FN: AsFieldName<V>>(
+        mut self,
+        lam: impl Fn(<T as HasSchema>::Schema) -> FN,
+        as_name: &'static str,
+    ) -> SelectBuilder<T> {
+        let field = lam(Default::default());
+        self.selects.push(SelectColumn {
+            col_name: field.colname().to_string(),
+            field_name: as_name.to_string(),
+            kind: SelectKind::Sum,
+        });
+        self
+    }
+
     /// Filter the results returned by this query.
     /// Used when you want to filter on the columns of this table.
     pub fn where_col(

--- a/welds/src/query/select_cols/select_column.rs
+++ b/welds/src/query/select_cols/select_column.rs
@@ -33,6 +33,8 @@ pub(crate) enum SelectKind {
     Count,
     Max,
     Min,
+    Average,
+    Sum,
 }
 
 /// used while writing SQL to help keep track of parts of the select
@@ -79,6 +81,12 @@ impl SelectRender {
             }
             SelectKind::Min => {
                 format!("MIN({}.{}) AS {}", self.alias, colname, fieldname)
+            }
+            SelectKind::Average => {
+                format!("AVG({}.{}) AS {}", self.alias, colname, fieldname)
+            }
+            SelectKind::Sum => {
+                format!("SUM({}.{}) AS {}", self.alias, colname, fieldname)
             }
         }
     }


### PR DESCRIPTION
We were missing 2 of the 5 "major" aggregate functions (COUNT, SUM, AVG, MIN, MAX). Added implementation for SUM and AVG.