### PR TITLE
feat: adding sync support

### DIFF
--- a/welds-connections/Cargo.toml
+++ b/welds-connections/Cargo.toml
@@ -18,6 +18,7 @@ description = "An async ORM for (postgres, mssql, mysql, sqlite)"
 "postgres" = ["sqlx/postgres"]
 "mysql" = ["sqlx/mysql"]
 "sqlite" = ["sqlx/sqlite"]
+"sqlite-sync" = ["__sync", "rusqlite", "rusqlite/chrono", "rusqlite/uuid"]
 "mssql" = ["tokio", "tokio-util", "futures-util", "tiberius", "bb8-tiberius", "bb8", "futures", "async-mutex"]
 "mssql-chrono" = ["tiberius/chrono"]
 "mssql-time" = ["tiberius/time"]
@@ -27,7 +28,10 @@ description = "An async ORM for (postgres, mssql, mysql, sqlite)"
 "tracing" = ["dep:tracing"]
 "unstable-api" = ["futures", "futures-core"]
 "full" = ["postgres", "mysql", "sqlite", "mssql", "noop", "unstable-api"]
+"full-sync" = ["sqlite-sync"]
 
+# Internal feature for enabling sync compilation
+"__sync" = ["maybe-async/is_sync"]
 
 [dependencies]
 async-trait = "0.1"
@@ -39,10 +43,14 @@ futures-core = {version= "0.3", optional=true }
 futures-util = { version= "0.3", optional=true }
 log = "0.4"
 sqlx = { version = "0.8", features = [], optional = true }
+# NOTE: we *need* to pin rusqlite to 0.32.x due to libsqlite-sys version incompatibilities conflicting with sqlx's
+# When sqlx is updated, we will need to re-verify this constraint
+rusqlite = { version = "=0.32", optional = true }
 tracing = { version = "0.1", optional = true }
 tokio = { version = "1", features = [], optional = true }
 tokio-util = { version = "0.7", features = ["full"], optional = true }
 async-mutex = { version = "1.4", optional = true }
+maybe-async = "0.2.10"
 
 [dev-dependencies]
 welds-connections = { path="./", features = ["full"] }

--- a/welds-connections/src/errors/mod.rs
+++ b/welds-connections/src/errors/mod.rs
@@ -10,6 +10,8 @@ pub enum Error {
     TiberiusConnPool(bb8_tiberius::Error),
     #[cfg(feature = "mssql")]
     Tiberius(tiberius::error::Error),
+    #[cfg(feature = "sqlite-sync")]
+    Rusqlite(rusqlite::Error),
     Bb8(&'static str),
     InvalidDatabaseUrl,
     RowNowFound,
@@ -27,6 +29,8 @@ impl Display for Error {
         let message = match self {
             #[cfg(any(feature = "mysql", feature = "sqlite", feature = "postgres"))]
             Error::Sqlx(err) => err.to_string(),
+            #[cfg(feature = "sqlite-sync")]
+            Error::Rusqlite(err) => err.to_string(),
             #[cfg(feature = "mssql")]
             Error::TiberiusConnPool(err) => err.to_string(),
             #[cfg(feature = "mssql")]
@@ -79,5 +83,12 @@ impl<T> From<bb8::RunError<T>> for Error {
 impl From<tiberius::error::Error> for Error {
     fn from(inner: tiberius::error::Error) -> Self {
         Error::Tiberius(inner)
+    }
+}
+
+#[cfg(feature = "sqlite-sync")]
+impl From<rusqlite::Error> for Error {
+    fn from(inner: rusqlite::Error) -> Self {
+        Error::Rusqlite(inner)
     }
 }

--- a/welds-connections/src/params/mod.rs
+++ b/welds-connections/src/params/mod.rs
@@ -8,6 +8,9 @@ use sqlx::types::Type;
 #[cfg(feature = "sqlite")]
 use super::sqlite::SqliteParam;
 
+#[cfg(feature = "sqlite-sync")]
+use super::sqlite_sync::SqliteSyncParam;
+
 #[cfg(feature = "mssql")]
 use super::mssql::MssqlParam;
 
@@ -16,6 +19,12 @@ use super::postgres::PostgresParam;
 
 #[cfg(feature = "mysql")]
 use super::mysql::MysqlParam;
+
+#[cfg(all(feature = "sqlite-sync"))]
+pub trait Param: SqliteSyncParam + rusqlite::types::ToSql {}
+
+#[cfg(all(feature = "sqlite-sync"))]
+impl<T> Param for T where T: rusqlite::types::FromSql + rusqlite::types::ToSql {}
 
 #[cfg(all(
     feature = "sqlite",

--- a/welds-connections/src/sqlite_sync/mod.rs
+++ b/welds-connections/src/sqlite_sync/mod.rs
@@ -1,0 +1,133 @@
+use super::TransactStart;
+use super::transaction::{TransT, Transaction};
+use super::{Client, Param};
+use super::{Row, trace};
+use crate::ExecuteResult;
+use crate::errors::Result;
+use rusqlite::types::{FromSql, ToSql, ValueRef};
+use std::sync::MutexGuard;
+use std::sync::{Arc, Mutex};
+
+#[derive(Clone)]
+pub struct SqliteClient {
+    conn: Arc<Mutex<rusqlite::Connection>>,
+}
+
+// required to own the row
+pub struct SqliteSyncOwnedRow {
+    pub data: Vec<rusqlite::types::Value>, // rusqlite::types::Value is owned
+    pub columns: Arc<Vec<String>>,
+}
+
+impl SqliteSyncOwnedRow {
+    pub fn try_get<T>(&self, idx: usize) -> rusqlite::Result<T>
+    where
+        T: FromSql,
+    {
+        let value = &self.data[idx];
+        let value_ref = ValueRef::from(value);
+        Ok(T::column_result(value_ref)?)
+    }
+}
+
+impl Client for SqliteClient {
+    fn execute(&self, sql: &str, params: &[&(dyn Param + Sync)]) -> Result<ExecuteResult> {
+        log::trace!("SQLITE EXECUTE: {}", sql);
+        let mut p = Vec::new();
+        for param in params {
+            p.push(SqliteSyncParam::to_sql_dyn(param));
+        }
+        let r = trace::db_error(self.conn.lock().unwrap().execute(sql, &*p))?;
+        Ok(ExecuteResult::new(r as u64))
+    }
+
+    fn fetch_rows(&self, sql: &str, params: &[&(dyn Param + Sync)]) -> Result<Vec<Row>> {
+        log::trace!("SQLITE FETCH_ROWS: {}", sql);
+        let mut p = Vec::new();
+        for param in params {
+            p.push(SqliteSyncParam::to_sql_dyn(param));
+        }
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = conn.prepare(sql)?;
+        let column_names: Vec<String> = stmt.column_names().iter().map(|s| s.to_string()).collect();
+        let columns = Arc::new(column_names);
+
+        let mut raw_rows = trace::db_error(stmt.query(&*p))?;
+        let mut res = Vec::new();
+
+        while let Some(row) = raw_rows.next()? {
+            let mut data = Vec::new();
+            for i in 0..row.as_ref().column_count() {
+                data.push(row.get::<_, rusqlite::types::Value>(i)?);
+            }
+            res.push(Row::from(SqliteSyncOwnedRow {
+                data,
+                columns: Arc::clone(&columns),
+            }));
+        }
+        Ok(res)
+    }
+
+    fn fetch_many<'s, 'args, 't>(
+        &self,
+        fetches: &[crate::Fetch<'s, 'args, 't>],
+    ) -> Result<Vec<Vec<Row>>> {
+        let mut datasets = Vec::default();
+        for fetch in fetches {
+            let sql = fetch.sql;
+            log::trace!("SQLITE FETCH_MANY: {}", sql);
+            let params = fetch.params;
+            let rows = self.fetch_rows(sql, params)?;
+            datasets.push(rows);
+        }
+        Ok(datasets)
+    }
+
+    fn syntax(&self) -> crate::Syntax {
+        crate::Syntax::Sqlite
+    }
+}
+
+pub struct SqliteSyncTransaction<'a> {
+    _guard: MutexGuard<'a, rusqlite::Connection>,
+    pub transaction: rusqlite::Transaction<'a>,
+}
+
+impl TransactStart for SqliteClient {
+    fn begin<'t>(&'t self) -> Result<Transaction<'t>> {
+        let mut guard = self.conn.lock().unwrap();
+        // We need to create the transaction from the guard
+        // This requires unsafe because we're creating a self-referential struct
+        let transaction = unsafe {
+            let conn_ptr = &mut *guard as *mut rusqlite::Connection;
+            (*conn_ptr).transaction()?
+        };
+        let t = SqliteSyncTransaction {
+            _guard: guard,
+            transaction,
+        };
+        let t = TransT::SqliteSync(t);
+        Ok(Transaction::new(t))
+    }
+}
+
+pub fn connect(url: &str) -> Result<SqliteClient> {
+    let path = url.trim_start_matches("sqlite://");
+    let client = rusqlite::Connection::open(path)?;
+    Ok(SqliteClient {
+        conn: Arc::new(Mutex::new(client)),
+    })
+}
+
+pub trait SqliteSyncParam {
+    fn to_sql_dyn(&self) -> &dyn ToSql;
+}
+
+impl<T> SqliteSyncParam for T
+where
+    T: ToSql,
+{
+    fn to_sql_dyn(&self) -> &dyn ToSql {
+        self
+    }
+}

--- a/welds-connections/src/transaction/mod.rs
+++ b/welds-connections/src/transaction/mod.rs
@@ -8,16 +8,22 @@ use std::sync::Mutex;
 #[cfg(feature = "mssql")]
 use crate::mssql::transaction::MssqlTransaction;
 
+#[cfg(feature = "sqlite-sync")]
+use crate::sqlite_sync::SqliteSyncTransaction;
+
 pub struct Transaction<'t> {
     inner: Mutex<Option<TransT<'t>>>,
     syntax: crate::Syntax,
 }
 
+#[maybe_async::maybe_async]
 impl<'t> Transaction<'t> {
     pub(crate) fn new(inner: TransT<'t>) -> Self {
         let syntax = match &inner {
             #[cfg(feature = "sqlite")]
             TransT::Sqlite(_) => Syntax::Sqlite,
+            #[cfg(feature = "sqlite-sync")]
+            TransT::SqliteSync(_) => Syntax::Sqlite,
             #[cfg(feature = "mssql")]
             TransT::Mssql(_) => Syntax::Mssql,
             #[cfg(feature = "postgres")]
@@ -72,6 +78,8 @@ impl<'t> Transaction<'t> {
 pub(crate) enum TransT<'t> {
     #[cfg(feature = "sqlite")]
     Sqlite(sqlx::Transaction<'t, sqlx::Sqlite>),
+    #[cfg(feature = "sqlite-sync")]
+    SqliteSync(SqliteSyncTransaction<'t>),
     #[cfg(feature = "postgres")]
     Postgres(sqlx::Transaction<'t, sqlx::Postgres>),
     #[cfg(feature = "mysql")]
@@ -80,11 +88,14 @@ pub(crate) enum TransT<'t> {
     Mssql(MssqlTransaction<'t>),
 }
 
+#[maybe_async::maybe_async]
 impl TransT<'_> {
     async fn rollback(self) -> Result<()> {
         match self {
             #[cfg(feature = "sqlite")]
             TransT::Sqlite(t) => t.rollback().await?,
+            #[cfg(feature = "sqlite-sync")]
+            TransT::SqliteSync(t) => t.transaction.rollback().await?,
             #[cfg(feature = "mssql")]
             TransT::Mssql(t) => t.rollback().await?,
             #[cfg(feature = "postgres")]
@@ -98,6 +109,8 @@ impl TransT<'_> {
         match self {
             #[cfg(feature = "sqlite")]
             TransT::Sqlite(t) => t.commit().await?,
+            #[cfg(feature = "sqlite-sync")]
+            TransT::SqliteSync(t) => t.transaction.commit()?,
             #[cfg(feature = "mssql")]
             TransT::Mssql(t) => t.commit().await?,
             #[cfg(feature = "postgres")]
@@ -115,7 +128,10 @@ use super::mysql::MysqlParam;
 use super::postgres::PostgresParam;
 #[cfg(feature = "sqlite")]
 use super::sqlite::SqliteParam;
+#[cfg(feature = "sqlite-sync")]
+use super::sqlite_sync::SqliteSyncParam;
 
+#[maybe_async::maybe_async]
 #[async_trait]
 impl Client for Transaction<'_> {
     fn syntax(&self) -> crate::Syntax {
@@ -159,6 +175,7 @@ impl Client for Transaction<'_> {
     }
 }
 
+#[maybe_async::maybe_async]
 async fn execute_inner(
     inner: &mut TransT<'_>,
     sql: &str,
@@ -176,6 +193,16 @@ async fn execute_inner(
             Ok(ExecuteResult {
                 rows_affected: t.rows_affected(),
             })
+        }
+
+        #[cfg(feature = "sqlite-sync")]
+        TransT::SqliteSync(t) => {
+            let mut p = Vec::new();
+            for param in params {
+                p.push(SqliteSyncParam::to_sql_dyn(param));
+            }
+            let r = t.transaction.execute(sql, &*p)?;
+            Ok(ExecuteResult::new(r as u64))
         }
 
         #[cfg(feature = "postgres")]
@@ -215,6 +242,7 @@ async fn execute_inner(
     }
 }
 
+#[maybe_async::maybe_async]
 async fn fetch_rows_inner(
     inner: &mut TransT<'_>,
     sql: &str,
@@ -231,6 +259,34 @@ async fn fetch_rows_inner(
             let mut raw_rows = query.fetch_all(x).await?;
             let rows: Vec<Row> = raw_rows.drain(..).map(Row::from).collect();
             Ok(rows)
+        }
+
+        #[cfg(feature = "sqlite-sync")]
+        TransT::SqliteSync(t) => {
+            use super::sqlite_sync::SqliteSyncOwnedRow;
+            use std::sync::Arc;
+            let mut p = Vec::new();
+            for param in params {
+                p.push(SqliteSyncParam::to_sql_dyn(param));
+            }
+            let mut stmt = t.transaction.prepare(sql)?;
+            let column_names: Vec<String> =
+                stmt.column_names().iter().map(|s| s.to_string()).collect();
+            let columns = Arc::new(column_names);
+
+            let mut raw_rows = stmt.query(&*p)?;
+            let mut res = Vec::new();
+            while let Some(row) = raw_rows.next()? {
+                let mut data = Vec::new();
+                for i in 0..row.as_ref().column_count() {
+                    data.push(row.get::<_, rusqlite::types::Value>(i)?);
+                }
+                res.push(Row::from(SqliteSyncOwnedRow {
+                    data,
+                    columns: Arc::clone(&columns),
+                }));
+            }
+            Ok(res)
         }
 
         #[cfg(feature = "postgres")]

--- a/welds-macros/Cargo.toml
+++ b/welds-macros/Cargo.toml
@@ -20,3 +20,6 @@ proc-macro2 = "1"
 
 [features]
 "default" = []
+
+# Internal feature for enabling sync compilation
+"__sync" = []

--- a/welds-macros/src/blocks/impl_struct/fn_find_by_id.rs
+++ b/welds-macros/src/blocks/impl_struct/fn_find_by_id.rs
@@ -19,9 +19,20 @@ pub(crate) fn write(info: &Info) -> TokenStream {
     let filters: Vec<_> = pks.iter().map(filter).collect();
     let filters = quote! {#(#filters)* };
 
+    let async_token = if cfg!(feature = "__sync") {
+        quote! {}
+    } else {
+        quote! { async }
+    };
+    let await_token = if cfg!(feature = "__sync") {
+        quote! {}
+    } else {
+        quote! { .await }
+    };
+
     quote! {
 
-    pub async fn find_by_id(
+    pub #async_token fn find_by_id(
         conn: &dyn #wp::Client,
         #id_params
     ) -> #wp::errors::Result<Option<#wp::state::DbState<Self>>>
@@ -32,7 +43,7 @@ pub(crate) fn write(info: &Info) -> TokenStream {
         #converts
         let mut q = Self::all();
         #filters
-        let mut results = q.limit(1).run(conn).await?;
+        let mut results = q.limit(1).run(conn)#await_token?;
         Ok(results.pop())
     }
 

--- a/welds-macros/src/blocks/impl_struct/fn_truncate.rs
+++ b/welds-macros/src/blocks/impl_struct/fn_truncate.rs
@@ -4,9 +4,19 @@ use quote::quote;
 
 pub(crate) fn write(info: &Info) -> TokenStream {
     let wp = &info.welds_path;
+    let async_token = if cfg!(feature = "__sync") {
+        quote! {}
+    } else {
+        quote! { async }
+    };
+    let await_token = if cfg!(feature = "__sync") {
+        quote! {}
+    } else {
+        quote! { .await }
+    };
 
     quote! {
-    pub async fn truncate<C, DB>(conn: &C) -> #wp::errors::Result<()>
+    pub #async_token fn truncate<C, DB>(conn: &C) -> #wp::errors::Result<()>
     where
         C: #wp::connection::Connection<DB>,
         DB: #wp::connection::Database,
@@ -15,7 +25,7 @@ pub(crate) fn write(info: &Info) -> TokenStream {
             <<Self as #wp::table::HasSchema>::Schema as #wp::table::TableInfo>::identifier();
         let identifier = nameparts.join(".");
         let sql = format!("TRUNCATE {}", identifier);
-        conn.execute(&sql, Default::default()).await?;
+        conn.execute(&sql, Default::default())#await_token?;
         Ok(())
     }
 

--- a/welds-macros/src/blocks/jointable.rs
+++ b/welds-macros/src/blocks/jointable.rs
@@ -38,34 +38,44 @@ fn write_link_unlink(info: &Info, relation_a: &Relation, relation_b: &Relation) 
     let model_struct = &info.defstruct;
     let struct_a = &relation_a.foreign_struct;
     let struct_b = &relation_b.foreign_struct;
+    let async_token = if cfg!(feature = "__sync") {
+        quote! {}
+    } else {
+        quote! { async }
+    };
+    let await_token = if cfg!(feature = "__sync") {
+        quote! {}
+    } else {
+        quote! { .await }
+    };
     quote! {
 
         impl #model_struct {
-            pub async fn link(
+            pub #async_token fn link(
                 model_a: &mut #wp::state::DbState<#struct_a>,
                 model_b: &mut #wp::state::DbState<#struct_b>,
                 client: &dyn Client,
             ) -> welds::errors::Result<()> {
                 // save if needed
                 if model_a.db_status() != #wp::state::DbStatus::NotModified {
-                    model_a.save(client).await?;
+                    model_a.save(client)#await_token?;
                 }
                 if model_b.db_status() != #wp::state::DbStatus::NotModified {
-                    model_b.save(client).await?;
+                    model_b.save(client)#await_token?;
                 }
                 let a: &#struct_a = model_a;
                 let b: &#struct_b = model_b;
-                #wp::query::link::create::<#model_struct, _, _>(client, a, b).await?;
+                #wp::query::link::create::<#model_struct, _, _>(client, a, b)#await_token?;
                 Ok(())
             }
-            pub async fn unlink(
+            pub #async_token fn unlink(
                 model_a: &#struct_a,
                 model_b: &#struct_b,
                 client: &dyn Client,
             ) -> welds::errors::Result<()> {
                 let a: &#struct_a = model_a;
                 let b: &#struct_b = model_b;
-                #wp::query::link::delete::<#model_struct, _, _>(client, a, b).await?;
+                #wp::query::link::delete::<#model_struct, _, _>(client, a, b)#await_token?;
                 Ok(())
             }
         }

--- a/welds-macros/src/blocks/write_hooks.rs
+++ b/welds-macros/src/blocks/write_hooks.rs
@@ -50,9 +50,15 @@ pub(crate) fn write_before_create(info: &Info) -> TokenStream {
         .collect();
     let hook_calls = quote! { #(#hook_calls)* };
 
+    let async_token = if cfg!(feature = "__sync") {
+        quote! {}
+    } else {
+        quote! { async }
+    };
+
     quote! {
         impl #wp::model_traits::hooks::BeforeCreate for #def {
-            async fn before(&mut self) -> #wp::errors::Result<()> {
+            #async_token fn before(&mut self) -> #wp::errors::Result<()> {
                 #hook_calls
                 Ok(())
             }
@@ -80,9 +86,15 @@ pub(crate) fn write_after_create(info: &Info) -> TokenStream {
         .collect();
     let hook_calls = quote! { #(#hook_calls)* };
 
+    let async_token = if cfg!(feature = "__sync") {
+        quote! {}
+    } else {
+        quote! { async }
+    };
+
     quote! {
         impl #wp::model_traits::hooks::AfterCreate for #def {
-            async fn after(&self) -> #wp::errors::Result<()> {
+            #async_token fn after(&self) -> #wp::errors::Result<()> {
                 #hook_calls
                 Ok(())
             }
@@ -112,9 +124,15 @@ pub(crate) fn write_before_update(info: &Info) -> TokenStream {
         .collect();
     let hook_calls = quote! { #(#hook_calls)* };
 
+    let async_token = if cfg!(feature = "__sync") {
+        quote! {}
+    } else {
+        quote! { async }
+    };
+
     quote! {
         impl #wp::model_traits::hooks::BeforeUpdate for #def {
-            async fn before(&mut self) -> #wp::errors::Result<()> {
+            #async_token fn before(&mut self) -> #wp::errors::Result<()> {
                 #hook_calls
                 Ok(())
             }
@@ -142,9 +160,15 @@ pub(crate) fn write_after_update(info: &Info) -> TokenStream {
         .collect();
     let hook_calls = quote! { #(#hook_calls)* };
 
+    let async_token = if cfg!(feature = "__sync") {
+        quote! {}
+    } else {
+        quote! { async }
+    };
+
     quote! {
         impl #wp::model_traits::hooks::AfterUpdate for #def {
-            async fn after(&self) -> #wp::errors::Result<()> {
+            #async_token fn after(&self) -> #wp::errors::Result<()> {
                 #hook_calls
                 Ok(())
             }
@@ -174,9 +198,15 @@ pub(crate) fn write_before_delete(info: &Info) -> TokenStream {
         .collect();
     let hook_calls = quote! { #(#hook_calls)* };
 
+    let async_token = if cfg!(feature = "__sync") {
+        quote! {}
+    } else {
+        quote! { async }
+    };
+
     quote! {
         impl #wp::model_traits::hooks::BeforeDelete for #def {
-            async fn before(&self) -> #wp::errors::Result<()> {
+            #async_token fn before(&self) -> #wp::errors::Result<()> {
                 #hook_calls
                 Ok(())
             }
@@ -204,9 +234,15 @@ pub(crate) fn write_after_delete(info: &Info) -> TokenStream {
         .collect();
     let hook_calls = quote! { #(#hook_calls)* };
 
+    let async_token = if cfg!(feature = "__sync") {
+        quote! {}
+    } else {
+        quote! { async }
+    };
+
     quote! {
         impl #wp::model_traits::hooks::AfterDelete for #def {
-            async fn after(&self) -> #wp::errors::Result<()> {
+            #async_token fn after(&self) -> #wp::errors::Result<()> {
                 #hook_calls
                 Ok(())
             }

--- a/welds/Cargo.toml
+++ b/welds/Cargo.toml
@@ -19,6 +19,7 @@ colored = { version="3", optional = true }
 anyhow = "1.0"
 thiserror = "2.0"
 welds-macros = { path="../welds-macros", version = "^0.4.20" }
+maybe-async = "0.2.10"
 
 [features]
 "default" = []
@@ -26,7 +27,9 @@ welds-macros = { path="../welds-macros", version = "^0.4.20" }
 "mysql" = ["welds-connections/mysql"]
 "mssql" = ["welds-connections/mssql"]
 "sqlite" = ["welds-connections/sqlite"]
+"sqlite-sync" = ["__sync", "welds-connections/sqlite-sync"]
 "full" = ["postgres", "mysql", "mssql", "sqlite", "check", "detect", "migrations", "unstable-api"]
+"full-sync" = ["sqlite-sync", "check", "detect", "migrations"]
 "detect" = []
 "mock" = []
 "check" = ["detect", "colored"]
@@ -34,6 +37,8 @@ welds-macros = { path="../welds-macros", version = "^0.4.20" }
 "unstable-api" = ["welds-connections/unstable-api", "futures", "futures-core"]
 "tracing" = ["welds-connections/tracing"]
 
+# Internal feature for enabling sync compilation
+"__sync" = ["maybe-async/is_sync", "welds-macros/__sync", "welds-connections/__sync"]
 
 #[profile.dev.package.sqlx-macros]
 #opt-level = 3

--- a/welds/src/check/mod.rs
+++ b/welds/src/check/mod.rs
@@ -13,6 +13,7 @@ pub use issue::*;
 /// and what the welds object was compiled against
 ///
 /// Used to known if there are going to be issues when running the query of a model
+#[maybe_async::maybe_async]
 pub async fn schema<T>(client: &dyn Client) -> Result<Vec<Issue>>
 where
     T: Send + HasSchema,

--- a/welds/src/detect/mod.rs
+++ b/welds/src/detect/mod.rs
@@ -23,12 +23,14 @@ pub use table_def::{ColumnDef, DataType, RelationDef, TableDef, TableDefSingle};
 /// Returns a list of all user defined tables in the database
 /// requires feature `detect`
 #[deprecated(since = "0.4.11", note = "please use `find_all_tables` instead.")]
+#[maybe_async::maybe_async]
 pub async fn find_tables(client: &dyn Client) -> Result<Vec<TableDef>> {
     find_all_tables(client).await
 }
 
 /// Returns a list of all user defined tables in the database
 /// requires feature `detect`
+#[maybe_async::maybe_async]
 pub async fn find_all_tables(client: &dyn Client) -> Result<Vec<TableDef>> {
     let syntax = client.syntax();
     let ts = TableScan::new(syntax);
@@ -57,6 +59,7 @@ pub async fn find_all_tables(client: &dyn Client) -> Result<Vec<TableDef>> {
 /// Will return Err if two tables with the same name exist. (Ex: "welds.Products" and "welds.products").
 /// Use table_search if you are expecting multiple table name.
 /// NOTE: does not include relationship info. use find_all_tables for that
+#[maybe_async::maybe_async]
 pub async fn find_table(
     namespace: Option<impl Into<String>>,
     tablename: impl Into<String>,
@@ -99,6 +102,7 @@ pub async fn find_table(
 /// Can use SQL wildcard.
 /// NOTE: namespace and tablename are case insensitive (using ilike)
 /// NOTE: Does not include relationship info. Use find_all_tables for that
+#[maybe_async::maybe_async]
 pub async fn table_search(
     namespace: Option<impl Into<String>>,
     tablename: impl Into<String>,

--- a/welds/src/migrations/mod.rs
+++ b/welds/src/migrations/mod.rs
@@ -26,6 +26,7 @@ pub use manual::Manual;
 pub type MigrationFn = fn(state: &TableState) -> Result<MigrationStep>;
 
 /// Migrate your database to the latest in the list of migrations
+#[maybe_async::maybe_async]
 pub async fn up(client: &dyn TransactStart, migrations: &[MigrationFn]) -> Result<()> {
     //make the migration table if needed
     {
@@ -71,6 +72,7 @@ pub async fn up(client: &dyn TransactStart, migrations: &[MigrationFn]) -> Resul
     Ok(())
 }
 
+#[maybe_async::maybe_async]
 async fn setup_migration_table(trans: Transaction<'_>) -> Result<()> {
     // make sure the migration table exists
     let setup = migration_table().up_sql(trans.syntax());
@@ -93,6 +95,7 @@ fn unixtime() -> u128 {
 /// Rolls back the last migration that ran.
 /// return the name of the migration that rolled back
 /// None, there were not more migrations to rollback
+#[maybe_async::maybe_async]
 pub async fn down_last(client: &dyn TransactStart) -> Result<Option<String>> {
     //make the migration table if needed
     {
@@ -129,6 +132,7 @@ pub async fn down_last(client: &dyn TransactStart) -> Result<Option<String>> {
 /// Rolls back the given migration.
 /// return the name of the migration that rolled back
 /// None, there were no matching migrations to rollback
+#[maybe_async::maybe_async]
 pub async fn down(client: &dyn TransactStart, name: impl Into<String>) -> Result<Option<String>> {
     //make the migration table if needed
     {
@@ -190,6 +194,7 @@ pub struct MigrationLog {
     pub(crate) rollback_sql: String,
 }
 
+#[maybe_async::maybe_async]
 async fn get_state(client: &dyn Client) -> Result<TableState> {
     let state = detect::find_all_tables(client).await?;
     Ok(TableState(state))

--- a/welds/src/model_traits/hooks.rs
+++ b/welds/src/model_traits/hooks.rs
@@ -15,16 +15,23 @@ pub trait BeforeCreate {
     /// you can force a cancel by returning `welds::errors::weldsError::ActionCanceled`
     ///
     /// you can also return any anyhow errors. Useful for things like validation
+    #[cfg(not(feature = "__sync"))]
     fn before(&mut self) -> impl std::future::Future<Output = Result<()>> + Send;
+    #[maybe_async::sync_impl]
+    fn before(&mut self) -> Result<()>;
 }
 
+#[maybe_async::maybe_async]
 pub trait BeforeUpdate {
     /// a last minute opportunity to check/edit a model before it is saved to the database
     /// Err results will cancel the action.
     /// you can force a cancel by returning `welds::errors::weldsError::ActionCanceled`
     ///
     /// you can also return any anyhow errors. Useful for things like validation
+    #[cfg(not(feature = "__sync"))]
     fn before(&mut self) -> impl std::future::Future<Output = Result<()>> + Send;
+    #[maybe_async::sync_impl]
+    fn before(&mut self) -> Result<()>;
 }
 
 pub trait BeforeDelete {
@@ -33,26 +40,38 @@ pub trait BeforeDelete {
     /// you can force a cancel by returning `welds::errors::weldsError::ActionCanceled`
     ///
     /// you can also return any anyhow errors. Useful for things like validation
+    #[cfg(not(feature = "__sync"))]
     fn before(&self) -> impl std::future::Future<Output = Result<()>> + Send;
+    #[maybe_async::sync_impl]
+    fn before(&self) -> Result<()>;
 }
 
 pub trait AfterCreate {
     /// A way go get informed when a model is created in the database.
     ///
     /// is called after a model is created
+    #[cfg(not(feature = "__sync"))]
     fn after(&self) -> impl std::future::Future<Output = Result<()>> + Send;
+    #[maybe_async::sync_impl]
+    fn after(&self) -> Result<()>;
 }
 
 pub trait AfterUpdate {
     /// A way go get informed when a model is updated in the database.
     ///
     /// is called after a model is created
+    #[cfg(not(feature = "__sync"))]
     fn after(&self) -> impl std::future::Future<Output = Result<()>> + Send;
+    #[maybe_async::sync_impl]
+    fn after(&self) -> Result<()>;
 }
 
 pub trait AfterDelete {
     /// A way go get informed when a model is deleted from the database.
     ///
     /// is called after a model is deleted
+    #[cfg(not(feature = "__sync"))]
     fn after(&self) -> impl std::future::Future<Output = Result<()>> + Send;
+    #[maybe_async::sync_impl]
+    fn after(&self) -> Result<()>;
 }

--- a/welds/src/query/delete/bulk.rs
+++ b/welds/src/query/delete/bulk.rs
@@ -60,6 +60,7 @@ where
     /// Executes a `DELETE FROM ... `
     ///
     /// deletes all the resulting rows from the database
+    #[maybe_async::maybe_async]
     pub async fn delete(&self, client: &dyn Client) -> Result<u64>
     where
         <T as HasSchema>::Schema: UniqueIdentifier + TableInfo + TableColumns,

--- a/welds/src/query/delete/mod.rs
+++ b/welds/src/query/delete/mod.rs
@@ -10,6 +10,7 @@ use welds_connections::Client;
 
 pub mod bulk;
 
+#[maybe_async::maybe_async]
 pub async fn delete_one<T>(obj: &T, client: &dyn Client) -> Result<()>
 where
     T: HasSchema + WriteToArgs,

--- a/welds/src/query/include/exec.rs
+++ b/welds/src/query/include/exec.rs
@@ -31,6 +31,7 @@ where
     }
 
     /// Executes the query in the database returning the results
+    #[maybe_async::maybe_async]
     pub async fn run<'q, 'c>(&'q self, client: &'c dyn Client) -> Result<DataSet<T>>
     where
         'q: 'c,

--- a/welds/src/query/include/related_query.rs
+++ b/welds/src/query/include/related_query.rs
@@ -11,6 +11,7 @@ use async_trait::async_trait;
 use std::any::Any;
 use std::marker::PhantomData;
 
+#[maybe_async::maybe_async]
 #[async_trait]
 pub(crate) trait RelatedQuery<R> {
     async fn run(
@@ -35,6 +36,7 @@ where
     pub(crate) qb: QueryBuilder<R>,
 }
 
+#[maybe_async::maybe_async]
 #[async_trait]
 impl<R, T, Ship> RelatedQuery<T> for IncludeQuery<T, R, Ship>
 where

--- a/welds/src/query/insert/bulk.rs
+++ b/welds/src/query/insert/bulk.rs
@@ -8,6 +8,7 @@ use crate::writers::TableWriter;
 
 /// Executes the query in the database Bulk Inserting values
 /// The primary_keys will be inserted as part of the data
+#[maybe_async::maybe_async]
 pub async fn bulk_insert_with_ids<T>(conn: &dyn Client, data: &[T]) -> Result<()>
 where
     T: WriteToArgs + HasSchema,
@@ -21,6 +22,7 @@ where
 
 /// Executes the query in the database Bulk Inserting values
 /// The primary_keys will NOT be inserted as part of the data
+#[maybe_async::maybe_async]
 pub async fn bulk_insert<T>(conn: &dyn Client, data: &[T]) -> Result<()>
 where
     T: WriteToArgs + HasSchema,
@@ -37,6 +39,7 @@ where
 ///
 /// WARNING: This method does NOT protect the SQL generated tablename.
 /// DO NOT expose to end-users. SQL injection risk.
+#[maybe_async::maybe_async]
 pub async fn bulk_insert_with_ids_override_tablename_unsafe<T>(
     conn: &dyn Client,
     data: &[T],
@@ -55,6 +58,7 @@ where
 ///
 /// WARNING: This method does NOT protect the SQL generated tablename.
 /// DO NOT expose to end-users. SQL injection risk.
+#[maybe_async::maybe_async]
 pub async fn bulk_insert_override_tablename_unsafe<T>(
     conn: &dyn Client,
     data: &[T],
@@ -69,6 +73,7 @@ where
 }
 
 /// Executes the query in the database Bulk Inserting values
+#[maybe_async::maybe_async]
 async fn run<T>(conn: &dyn Client, data: &[T], with_ids: bool, tablename: &str) -> Result<()>
 where
     T: WriteToArgs + HasSchema,

--- a/welds/src/query/insert/single/mod.rs
+++ b/welds/src/query/insert/single/mod.rs
@@ -12,6 +12,7 @@ use crate::writers::insert::{ColArg, InsertWriter};
 use welds_connections::Client;
 use welds_connections::Fetch;
 
+#[maybe_async::maybe_async]
 pub async fn insert_one<T>(obj: &mut T, client: &dyn Client) -> Result<()>
 where
     T: WriteToArgs + HasSchema + ColumnDefaultCheck,

--- a/welds/src/query/link.rs
+++ b/welds/src/query/link.rs
@@ -15,6 +15,7 @@ use std::any::type_name;
 ///
 /// Warning: This function DOES NOT check that model_a or model_b is in the database.
 /// This is the responsibility of the calling code.
+#[maybe_async::maybe_async]
 pub async fn create<Link, A, B>(conn: &dyn Client, model_a: &A, model_b: &B) -> Result<()>
 where
     Link: WriteToArgs + HasSchema,
@@ -80,6 +81,7 @@ where
 /// deletes an instance of a <Link> model in the database linking model_a to model_b
 /// Success if link was not in database
 /// Fails only if there is a database issue.
+#[maybe_async::maybe_async]
 pub async fn delete<Link, A, B>(conn: &dyn Client, model_a: &A, model_b: &B) -> Result<()>
 where
     Link: WriteToArgs + HasSchema,

--- a/welds/src/query/select/mod.rs
+++ b/welds/src/query/select/mod.rs
@@ -23,6 +23,7 @@ pub use writer::SelectWriter;
 // This file contains all the stuff added onto the Querybuilder to allow it to run SELECTs
 // ******************************************************************************************
 
+#[maybe_async::maybe_async]
 impl<T> QueryBuilder<T>
 where
     T: Send + HasSchema,

--- a/welds/src/query/select_cols/exec.rs
+++ b/welds/src/query/select_cols/exec.rs
@@ -16,6 +16,7 @@ use welds_connections::trace;
 // This file contains all the stuff added onto the SelectBuilder to allow it to run SELECTs
 // ******************************************************************************************
 
+#[maybe_async::maybe_async]
 impl<T> SelectBuilder<T>
 where
     T: Send + HasSchema,

--- a/welds/src/query/update/bulk/mod.rs
+++ b/welds/src/query/update/bulk/mod.rs
@@ -27,6 +27,7 @@ pub struct UpdateBuilder<T> {
     pub(crate) sets: Vec<Arc<Box<dyn AssignmentAdder>>>,
 }
 
+#[maybe_async::maybe_async]
 impl<T> UpdateBuilder<T>
 where
     T: Send + HasSchema,

--- a/welds/src/query/update/single/mod.rs
+++ b/welds/src/query/update/single/mod.rs
@@ -7,6 +7,7 @@ use crate::writers::NextParam;
 use crate::writers::TableWriter;
 use welds_connections::Client;
 
+#[maybe_async::maybe_async]
 pub async fn update_one<T>(obj: &mut T, client: &dyn Client) -> Result<()>
 where
     T: WriteToArgs + HasSchema,

--- a/welds/src/state.rs
+++ b/welds/src/state.rs
@@ -42,6 +42,7 @@ where
     }
 }
 
+#[maybe_async::maybe_async]
 impl<T> DbState<T> {
     /// Returns status of the entity. If it is in the database/unsaved/modified/..
     pub fn db_status(&self) -> DbStatus {


### PR DESCRIPTION
I really enjoy welds' simple ergonomics as an ORM. However one thing I miss is sync support, as I prefer it over async in most cases. Making a whole program async just to communicate with the database isn't ideal.

This PR adds sync support via [maybe_async](https://github.com/fMeow/maybe-async-rs).
This has multiple advantages:
- No code duplication, which means no added maintenance burden 
- Easy to understand/use (a simple proc-macro)

Here is a summary of the changes I made to support sync:
- `welds`: welds' core was already more or less async-free, it only required it to communicate with `welds-connection`. Adding a bunch of `#[maybe_async::maybe_async]` was enough to convert it.
- `welds-macros`: changes were minimal as well, it only required a few tweaks to only emit `async fn`/ `.await` in the async case
- `welds-connections`: changes are more consequent as I added a new synchronous client to use with the new sync API. It's an sqlite client using [rusqlite](https://github.com/rusqlite/rusqlite)

New features added:
- `__sync`: internal feature used to enable/disable sync code compilation
- `sqlite-sync`: enables the sync sqlite client
- `full-sync`: same as `full` but for sync features

A couple of things to note:
- sync/async code is mutually exclusive, you can't compile both sync and async code at the same time. Allowing such a use case would require a much more consequent refactor
- I had to pin the exact `rusqlite` version because the `libsqlite3-sys` version was conflicting with `sqlx`. Maybe there's a more elegant solution

Although this PR might seem big, it's mostly just slapping a bunch of `#[maybe_async::maybe_async]` to enable both async and sync code. Hope you'll consider merging it!