### PR TITLE
build: adding sqlite-sync-bundled option

### DIFF
--- a/welds-connections/Cargo.toml
+++ b/welds-connections/Cargo.toml
@@ -19,6 +19,7 @@ description = "An async ORM for (postgres, mssql, mysql, sqlite)"
 "mysql" = ["sqlx/mysql"]
 "sqlite" = ["sqlx/sqlite"]
 "sqlite-sync" = ["__sync", "rusqlite", "rusqlite/chrono", "rusqlite/uuid"]
+"sqlite-sync-bundled" = ["sqlite-sync", "rusqlite/bundled"]
 "mssql" = ["tokio", "tokio-util", "futures-util", "tiberius", "bb8-tiberius", "bb8", "futures", "async-mutex"]
 "mssql-chrono" = ["tiberius/chrono"]
 "mssql-time" = ["tiberius/time"]

--- a/welds/Cargo.toml
+++ b/welds/Cargo.toml
@@ -28,6 +28,7 @@ maybe-async = "0.2"
 "mssql" = ["welds-connections/mssql"]
 "sqlite" = ["welds-connections/sqlite"]
 "sqlite-sync" = ["__sync", "welds-connections/sqlite-sync"]
+"sqlite-sync-bundled" = ["sqlite-sync", "welds-connections/sqlite-sync-bundled"]
 "full" = ["postgres", "mysql", "mssql", "sqlite", "check", "detect", "migrations", "unstable-api"]
 "full-sync" = ["sqlite-sync", "check", "detect", "migrations"]
 "detect" = []


### PR DESCRIPTION
adds an `sqlite-sync-bundled`, a variant of the existing `sqlite-sync` that actives the `rusqlite/bundled` feature to bundle `libsqlite3` statically into the binary (this is usually what you want when you use sqlite)